### PR TITLE
fix(build): use correct relative paths in `copy-frontend.sh`

### DIFF
--- a/scripts/copy-frontend.sh
+++ b/scripts/copy-frontend.sh
@@ -4,7 +4,9 @@ set -euo pipefail
 # https://stackoverflow.com/a/246128/4874344
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-frontend_destination_directory="$script_dir/backend/sirius-web-frontend/src/main/resources/static"
+repo_dir=$(realpath "$script_dir/..")
+
+frontend_destination_directory="$repo_dir/backend/sirius-web-frontend/src/main/resources/static"
 
 mkdir -p "$frontend_destination_directory"
-cp -R "$script_dir/frontend/build/*" "$frontend_destination_directory"
+cp -R "$repo_dir/frontend/build/" "$frontend_destination_directory"


### PR DESCRIPTION
The script assumed that `backend` and `frontend` directories were
relative to the script directory.

Closes #6