### PR TITLE
Fetch toolbox entries in the frontend and log them to the console

### DIFF
--- a/backend/sirius-web-sample-application/src/main/resources/application.properties
+++ b/backend/sirius-web-sample-application/src/main/resources/application.properties
@@ -26,3 +26,7 @@ logging.level.org.eclipse.sirius.web=debug
 sirius.components.cors.allowedOriginPatterns=*
 
 eu.balticlsc.model.features.modificationsEnabled=false
+
+eu.balticlsc.api-proxy.scheme=https
+eu.balticlsc.api-proxy.hostname=balticlsc.iem.pw.edu.pl
+eu.balticlsc.api-proxy.port=443

--- a/backend/sirius-web-spring/pom.xml
+++ b/backend/sirius-web-spring/pom.xml
@@ -81,6 +81,12 @@
 			<version>${sirius.components.version}</version>
 			<scope>test</scope>
 		</dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>5.3.12</version>
+    </dependency>
+
 	</dependencies>
 
 	<build>

--- a/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/configuration/BalticLSCProxyConfiguration.java
+++ b/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/configuration/BalticLSCProxyConfiguration.java
@@ -1,0 +1,38 @@
+package org.eclipse.sirius.web.spring.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "eu.balticlsc.api-proxy")
+public class BalticLSCProxyConfiguration {
+    private String scheme;
+
+    private int port;
+
+    private String hostname;
+
+    public String getScheme() {
+        return scheme;
+    }
+
+    public void setScheme(String scheme) {
+        this.scheme = scheme;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
+    }
+}

--- a/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/controllers/BalticLSCProxyController.java
+++ b/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/controllers/BalticLSCProxyController.java
@@ -1,0 +1,60 @@
+package org.eclipse.sirius.web.spring.controllers;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.sirius.web.spring.configuration.BalticLSCProxyConfiguration;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Controller
+@RequestMapping(URLConstants.BALTICLSC_PROXY_BASE_PATH)
+public class BalticLSCProxyController {
+    private final BalticLSCProxyConfiguration proxyConfiguration;
+
+    public BalticLSCProxyController(BalticLSCProxyConfiguration proxyConfiguration) {
+        this.proxyConfiguration = proxyConfiguration;
+    }
+
+    /**
+     * <p>
+     * Proxy requests to the BalticLSC server.
+     * </p>
+     *
+     * Credits to {@link https://stackoverflow.com/a/49429650/4874344}
+     */
+    @RequestMapping("/**")
+    public ResponseEntity<?> mirrorRest(@RequestBody(required = false) String body, HttpMethod method, HttpServletRequest request, HttpServletResponse response) throws URISyntaxException {
+        var requestUrl = request.getRequestURI();
+        var pathWithoutProxyPrefix = requestUrl.substring(URLConstants.BALTICLSC_PROXY_BASE_PATH.length());
+
+        var uri = new URI(proxyConfiguration.getScheme(), null, proxyConfiguration.getHostname(), proxyConfiguration.getPort(), null, null, null);
+        uri = UriComponentsBuilder.fromUri(uri).path(pathWithoutProxyPrefix).query(request.getQueryString()).build(true).toUri();
+
+        var headers = new HttpHeaders();
+        var headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            headers.set(headerName, request.getHeader(headerName));
+        }
+
+        var httpEntity = new HttpEntity<>(body, headers);
+        var restTemplate = new RestTemplate();
+        try {
+            return restTemplate.exchange(uri, method, httpEntity, String.class);
+        } catch (HttpStatusCodeException e) {
+            return ResponseEntity.status(e.getRawStatusCode()).headers(e.getResponseHeaders()).body(e.getResponseBodyAsString());
+        }
+    }
+}

--- a/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/controllers/URLConstants.java
+++ b/backend/sirius-web-spring/src/main/java/org/eclipse/sirius/web/spring/controllers/URLConstants.java
@@ -32,6 +32,8 @@ public final class URLConstants {
 
     public static final String PROJECT_BASE_PATH = API_BASE_PATH + "/projects"; //$NON-NLS-1$
 
+    public static final String BALTICLSC_PROXY_BASE_PATH = API_BASE_PATH + "/balticlsc-proxy"; //$NON-NLS-1$
+
     public static final String ANY_PATTERN = "/**"; //$NON-NLS-1$
 
     private URLConstants() {

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,2 +1,3 @@
 REACT_APP_HTTP_ORIGIN=http://localhost:8080
 REACT_APP_WS_ORIGIN=ws://localhost:8080
+REACT_APP_BALTICLSC_API_URL=http://localhost:8080/api/balticlsc-proxy

--- a/frontend/src/views/edit-project/EditProjectView.tsx
+++ b/frontend/src/views/edit-project/EditProjectView.tsx
@@ -147,6 +147,20 @@ export const EditProjectView = () => {
     representationId,
   ]);
 
+  useEffect(() => {
+    const toolboxUrl = `${process.env.REACT_APP_BALTICLSC_API_URL}/backend/dev/toolbox/`;
+    fetch(toolboxUrl, {
+      headers: {
+        authorization:
+          "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6ImRlbW8iLCJzdWIiOiJkZW1vIiwianRpIjoiYjQ5ZTJjZmQ0ZGQ5NDM1ODk1OTEwNmY0ZjcwNWY0YTciLCJzaWQiOiJiYjdhNTNhMjA1ZDM0NWY4YmNlYWRhYWEwZjkxZjhiNyIsImV4cCI6MTYzNjQwMzA3MywiaXNzIjoid3V0LmJhbHRpY2xzYy5ldSIsImF1ZCI6Ind1dC5iYWx0aWNsc2MuZXUifQ.RXUVe-i4_6TFdtbp1SYCB0yPowcX75bT59cd_ddrGt0",
+      },
+    })
+      .then((r) => r.json())
+      .then((response) => {
+        console.log("Got toolbox", response);
+      });
+  }, []);
+
   let main = null;
   if (editProjectView === "loaded" && project) {
     const onRepresentationSelected = (


### PR DESCRIPTION
Successfully fetch the toolbox contents from SIrius Web frontend. Uses Sirius Web backend as a proxy to the BalticLSC backend to circumvent CORS issues (BalticLSC backend does not allow for CORS).

![image](https://user-images.githubusercontent.com/889383/140809371-ebaf2871-96cc-4d35-a43a-1f29b680f6b6.png)

Closes #11 