### PR TITLE
chore(ci): prevent duplicate CI jobs for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build_frontend:


### PR DESCRIPTION
PRs had duplicate jobs:
* one set of jobs for the `push` event (for a given commit)
* another set of jobs for the `pull_request` event (for the whole PR)

See https://github.com/Gelio/CAL-web/pull/29/checks

This changes the configuration so that only commits on `main` are built
by the `push` event. Commits on other branches will be built in the
`pull_request` event.

This PR (https://github.com/Gelio/CAL-web/pull/30) only has a single set of jobs (for the `pull_request` event)