### PR TITLE
Upgrade sirius web to 0.5.3 and add an automation script

### DIFF
--- a/backend/sirius-web-frontend/pom.xml
+++ b/backend/sirius-web-frontend/pom.xml
@@ -30,7 +30,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.1</sirius.components.version>
+		<sirius.components.version>0.5.2</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-frontend/pom.xml
+++ b/backend/sirius-web-frontend/pom.xml
@@ -30,7 +30,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.2</sirius.components.version>
+		<sirius.components.version>0.5.3</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-graphql-schema/pom.xml
+++ b/backend/sirius-web-graphql-schema/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.1</sirius.components.version>
+		<sirius.components.version>0.5.2</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-graphql-schema/pom.xml
+++ b/backend/sirius-web-graphql-schema/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.2</sirius.components.version>
+		<sirius.components.version>0.5.3</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-graphql-schema/src/main/java/org/eclipse/sirius/web/graphql/schema/DiagramTypesProvider.java
+++ b/backend/sirius-web-graphql-schema/src/main/java/org/eclipse/sirius/web/graphql/schema/DiagramTypesProvider.java
@@ -36,6 +36,7 @@ import org.eclipse.sirius.web.diagrams.description.DiagramDescription;
 import org.eclipse.sirius.web.diagrams.description.NodeDescription;
 import org.eclipse.sirius.web.diagrams.tools.CreateEdgeTool;
 import org.eclipse.sirius.web.diagrams.tools.CreateNodeTool;
+import org.eclipse.sirius.web.diagrams.tools.DeleteTool;
 import org.eclipse.sirius.web.diagrams.tools.EdgeCandidate;
 import org.eclipse.sirius.web.diagrams.tools.ToolSection;
 import org.eclipse.sirius.web.graphql.utils.providers.GraphQLEnumTypeProvider;
@@ -65,6 +66,8 @@ public class DiagramTypesProvider implements ITypeProvider {
     public static final String CREATE_EDGE_TOOL_TYPE = "CreateEdgeTool"; //$NON-NLS-1$
 
     public static final String CREATE_NODE_TOOL_TYPE = "CreateNodeTool"; //$NON-NLS-1$
+
+    public static final String DELETE_TOOL_TYPE = "DeleteTool"; //$NON-NLS-1$
 
     public static final String TOOL_SECTION_TYPE = "ToolSection"; //$NON-NLS-1$
 
@@ -102,6 +105,7 @@ public class DiagramTypesProvider implements ITypeProvider {
             ToolSection.class,
             CreateEdgeTool.class,
             CreateNodeTool.class,
+            DeleteTool.class,
             EdgeCandidate.class
         );
         var graphQLObjectTypes = objectClasses.stream()

--- a/backend/sirius-web-graphql/pom.xml
+++ b/backend/sirius-web-graphql/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.1</sirius.components.version>
+		<sirius.components.version>0.5.2</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-graphql/pom.xml
+++ b/backend/sirius-web-graphql/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.2</sirius.components.version>
+		<sirius.components.version>0.5.3</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/diagram/DeleteToolImageURLDataFetcher.java
+++ b/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/diagram/DeleteToolImageURLDataFetcher.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.graphql.datafetchers.diagram;
+
+import org.eclipse.sirius.web.annotations.spring.graphql.QueryDataFetcher;
+import org.eclipse.sirius.web.diagrams.tools.ITool;
+import org.eclipse.sirius.web.graphql.schema.DiagramTypesProvider;
+import org.eclipse.sirius.web.graphql.schema.ImageURLFieldProvider;
+import org.eclipse.sirius.web.spring.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.eclipse.sirius.web.spring.graphql.api.URLConstants;
+
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * The data fetcher used to concatenate the server image URL to the delete element tool image path.
+ *
+ * @author arichard
+ */
+@QueryDataFetcher(type = DiagramTypesProvider.DELETE_TOOL_TYPE, field = ImageURLFieldProvider.IMAGE_URL_FIELD)
+public class DeleteToolImageURLDataFetcher implements IDataFetcherWithFieldCoordinates<String> {
+
+    @Override
+    public String get(DataFetchingEnvironment environment) throws Exception {
+        ITool tool = environment.getSource();
+        return URLConstants.IMAGE_BASE_PATH + tool.getImageURL();
+    }
+}

--- a/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/mutation/MutationDeleteListItemDataFetcher.java
+++ b/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/mutation/MutationDeleteListItemDataFetcher.java
@@ -1,0 +1,86 @@
+/***********************************************************************************************
+ * Copyright (c) 2021 Obeo. All Rights Reserved.
+ * This software and the attached documentation are the exclusive ownership
+ * of its authors and was conceded to the profit of Obeo SARL.
+ * This software and the attached documentation are protected under the rights
+ * of intellectual ownership, including the section "Titre II  Droits des auteurs (Articles L121-1 L123-12)"
+ * By installing this software, you acknowledge being aware of this rights and
+ * accept them, and as a consequence you must:
+ * - be in possession of a valid license of use conceded by Obeo only.
+ * - agree that you have read, understood, and will comply with the license terms and conditions.
+ * - agree not to do anything that could conflict with intellectual ownership owned by Obeo or its beneficiaries
+ * or the authors of this software
+ *
+ * Should you not agree with these terms, you must stop to use this software and give it back to its legitimate owner.
+ ***********************************************************************************************/
+package org.eclipse.sirius.web.graphql.datafetchers.mutation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.sirius.web.annotations.graphql.GraphQLMutationTypes;
+import org.eclipse.sirius.web.annotations.spring.graphql.MutationDataFetcher;
+import org.eclipse.sirius.web.core.api.ErrorPayload;
+import org.eclipse.sirius.web.core.api.IPayload;
+import org.eclipse.sirius.web.graphql.messages.IGraphQLMessageService;
+import org.eclipse.sirius.web.graphql.schema.MutationTypeProvider;
+import org.eclipse.sirius.web.spring.collaborative.api.IEditingContextEventProcessorRegistry;
+import org.eclipse.sirius.web.spring.collaborative.forms.dto.DeleteListItemInput;
+import org.eclipse.sirius.web.spring.collaborative.forms.dto.DeleteListItemSuccessPayload;
+import org.eclipse.sirius.web.spring.graphql.api.IDataFetcherWithFieldCoordinates;
+
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * The data fetcher used to delete a list item.
+ * <p>
+ * It will be used to handle the following GraphQL field:
+ * </p>
+ *
+ * <pre>
+ * type Mutation {
+ *   deleteListItem(input: DeleteListItemInput!): DeleteListItemPayload!
+ * }
+ * </pre>
+ *
+ * @author gcoutable
+ */
+// @formatter:off
+@GraphQLMutationTypes(
+    input = DeleteListItemInput.class,
+    payloads = {
+        DeleteListItemSuccessPayload.class
+    }
+)
+@MutationDataFetcher(type = MutationTypeProvider.TYPE, field = MutationDeleteListItemDataFetcher.DELETE_LIST_ITEM)
+// @formatter:on
+public class MutationDeleteListItemDataFetcher implements IDataFetcherWithFieldCoordinates<CompletableFuture<IPayload>> {
+
+    public static final String DELETE_LIST_ITEM = "deleteListItem"; //$NON-NLS-1$
+
+    private final ObjectMapper objectMapper;
+
+    private IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
+    private IGraphQLMessageService messageService;
+
+    public MutationDeleteListItemDataFetcher(ObjectMapper objectMapper, IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry, IGraphQLMessageService messageService) {
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+        this.messageService = Objects.requireNonNull(messageService);
+    }
+
+    @Override
+    public CompletableFuture<IPayload> get(DataFetchingEnvironment environment) throws Exception {
+        Object argument = environment.getArgument(MutationTypeProvider.INPUT_ARGUMENT);
+        var input = this.objectMapper.convertValue(argument, DeleteListItemInput.class);
+
+        // @formatter:off
+        return this.editingContextEventProcessorRegistry.dispatchEvent(input.getEditingContextId(), input)
+                .defaultIfEmpty(new ErrorPayload(input.getId(), this.messageService.unexpectedError())).toFuture();
+        // @formatter:on
+    }
+
+}

--- a/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/mutation/MutationInvokeDeleteToolOnDiagramDataFetcher.java
+++ b/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/mutation/MutationInvokeDeleteToolOnDiagramDataFetcher.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.graphql.datafetchers.mutation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.sirius.web.annotations.spring.graphql.MutationDataFetcher;
+import org.eclipse.sirius.web.core.api.ErrorPayload;
+import org.eclipse.sirius.web.core.api.IPayload;
+import org.eclipse.sirius.web.graphql.messages.IGraphQLMessageService;
+import org.eclipse.sirius.web.spring.collaborative.api.IEditingContextEventProcessorRegistry;
+import org.eclipse.sirius.web.spring.collaborative.diagrams.dto.InvokeDeleteToolOnDiagramInput;
+import org.eclipse.sirius.web.spring.graphql.api.IDataFetcherWithFieldCoordinates;
+
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * The data fetcher used to invoke a delete element tool on a diagram.
+ *
+ * @author arichard
+ */
+@MutationDataFetcher(type = "Mutation", field = "invokeDeleteToolOnDiagram")
+public class MutationInvokeDeleteToolOnDiagramDataFetcher implements IDataFetcherWithFieldCoordinates<CompletableFuture<IPayload>> {
+
+    private static final String INPUT_ARGUMENT = "input"; //$NON-NLS-1$
+
+    private final ObjectMapper objectMapper;
+
+    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
+    private final IGraphQLMessageService messageService;
+
+    public MutationInvokeDeleteToolOnDiagramDataFetcher(ObjectMapper objectMapper, IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry, IGraphQLMessageService messageService) {
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+        this.messageService = Objects.requireNonNull(messageService);
+    }
+
+    @Override
+    public CompletableFuture<IPayload> get(DataFetchingEnvironment environment) throws Exception {
+        Object argument = environment.getArgument(INPUT_ARGUMENT);
+        var input = this.objectMapper.convertValue(argument, InvokeDeleteToolOnDiagramInput.class);
+
+        // @formatter:off
+        return this.editingContextEventProcessorRegistry.dispatchEvent(input.getEditingContextId(), input)
+                .defaultIfEmpty(new ErrorPayload(input.getId(), this.messageService.unexpectedError()))
+                .toFuture();
+        // @formatter:on
+    }
+
+}

--- a/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/subscriptions/SubscriptionRepresentationsEventDataFetcher.java
+++ b/backend/sirius-web-graphql/src/main/java/org/eclipse/sirius/web/graphql/datafetchers/subscriptions/SubscriptionRepresentationsEventDataFetcher.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.graphql.datafetchers.subscriptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Objects;
+
+import org.eclipse.sirius.web.annotations.graphql.GraphQLSubscriptionTypes;
+import org.eclipse.sirius.web.annotations.spring.graphql.SubscriptionDataFetcher;
+import org.eclipse.sirius.web.core.api.IPayload;
+import org.eclipse.sirius.web.graphql.schema.SubscriptionTypeProvider;
+import org.eclipse.sirius.web.spring.collaborative.api.IEditingContextEventProcessorRegistry;
+import org.eclipse.sirius.web.spring.collaborative.dto.SubscribersUpdatedEventPayload;
+import org.eclipse.sirius.web.spring.collaborative.forms.api.IFormEventProcessor;
+import org.eclipse.sirius.web.spring.collaborative.forms.api.RepresentationsConfiguration;
+import org.eclipse.sirius.web.spring.collaborative.forms.dto.FormRefreshedEventPayload;
+import org.eclipse.sirius.web.spring.collaborative.forms.dto.PropertiesEventInput;
+import org.eclipse.sirius.web.spring.collaborative.forms.dto.RepresentationsEventInput;
+import org.eclipse.sirius.web.spring.collaborative.forms.dto.WidgetSubscriptionsUpdatedEventPayload;
+import org.eclipse.sirius.web.spring.graphql.api.IDataFetcherWithFieldCoordinates;
+import org.reactivestreams.Publisher;
+
+import graphql.schema.DataFetchingEnvironment;
+import reactor.core.publisher.Flux;
+
+/**
+ * The data fetcher used to send the refreshed representations form to a subscription.
+ * <p>
+ * It will used to fetch the data for the following GraphQL field:
+ * </p>
+ *
+ * <pre>
+ * type Subscription {
+ *   representationsEvent(input: RepresentationsEventInput): RepresentationsEventPayload
+ * }
+ * </pre>
+ *
+ * @author gcoutable
+ *
+ */
+//@formatter:off
+@GraphQLSubscriptionTypes(
+    input = RepresentationsEventInput.class,
+    payloads = {
+        FormRefreshedEventPayload.class,
+        WidgetSubscriptionsUpdatedEventPayload.class,
+        SubscribersUpdatedEventPayload.class,
+    }
+)
+@SubscriptionDataFetcher(type = SubscriptionTypeProvider.TYPE, field = SubscriptionRepresentationsEventDataFetcher.REPRESENTATIONS_EVENT_FIELD)
+//@formatter:on
+public class SubscriptionRepresentationsEventDataFetcher implements IDataFetcherWithFieldCoordinates<Publisher<IPayload>> {
+
+    public static final String REPRESENTATIONS_EVENT_FIELD = "representationsEvent"; //$NON-NLS-1$
+
+    private final ObjectMapper objectMapper;
+
+    private final IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry;
+
+    public SubscriptionRepresentationsEventDataFetcher(ObjectMapper objectMapper, IEditingContextEventProcessorRegistry editingContextEventProcessorRegistry) {
+        this.objectMapper = Objects.requireNonNull(objectMapper);
+        this.editingContextEventProcessorRegistry = Objects.requireNonNull(editingContextEventProcessorRegistry);
+    }
+
+    @Override
+    public Publisher<IPayload> get(DataFetchingEnvironment environment) throws Exception {
+        Object argument = environment.getArgument(SubscriptionTypeProvider.INPUT_ARGUMENT);
+        var input = this.objectMapper.convertValue(argument, PropertiesEventInput.class);
+        RepresentationsConfiguration representationsConfiguration = new RepresentationsConfiguration(input.getObjectId());
+
+        // @formatter:off
+        return this.editingContextEventProcessorRegistry.getOrCreateEditingContextEventProcessor(input.getEditingContextId())
+                .flatMap(processor -> processor.acquireRepresentationEventProcessor(IFormEventProcessor.class, representationsConfiguration, input))
+                .map(representationEventProcessor -> representationEventProcessor.getOutputEvents(input))
+                .orElse(Flux.empty());
+        // @formatter:on
+    }
+
+}

--- a/backend/sirius-web-persistence/pom.xml
+++ b/backend/sirius-web-persistence/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.1</sirius.components.version>
+		<sirius.components.version>0.5.2</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-persistence/pom.xml
+++ b/backend/sirius-web-persistence/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.2</sirius.components.version>
+		<sirius.components.version>0.5.3</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-sample-application/pom.xml
+++ b/backend/sirius-web-sample-application/pom.xml
@@ -31,8 +31,8 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.1</sirius.components.version>
-		<flow.version>1.0.7-SNAPSHOT</flow.version>
+		<sirius.components.version>0.5.2</sirius.components.version>
+		<flow.version>1.0.8-SNAPSHOT</flow.version>
     <CAL.model.version>0.1.0-SNAPSHOT</CAL.model.version>
 	</properties>
 

--- a/backend/sirius-web-sample-application/pom.xml
+++ b/backend/sirius-web-sample-application/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.2</sirius.components.version>
+		<sirius.components.version>0.5.3</sirius.components.version>
 		<flow.version>1.0.8-SNAPSHOT</flow.version>
     <CAL.model.version>0.1.0-SNAPSHOT</CAL.model.version>
 	</properties>

--- a/backend/sirius-web-services-api/pom.xml
+++ b/backend/sirius-web-services-api/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.1</sirius.components.version>
+		<sirius.components.version>0.5.2</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-services-api/pom.xml
+++ b/backend/sirius-web-services-api/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.2</sirius.components.version>
+		<sirius.components.version>0.5.3</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-services/pom.xml
+++ b/backend/sirius-web-services/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.1</sirius.components.version>
+		<sirius.components.version>0.5.2</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-services/pom.xml
+++ b/backend/sirius-web-services/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.2</sirius.components.version>
+		<sirius.components.version>0.5.3</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/representations/RepresentationsDescriptionProvider.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/representations/RepresentationsDescriptionProvider.java
@@ -1,0 +1,233 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.representations;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+
+import org.eclipse.sirius.web.compat.forms.WidgetIdProvider;
+import org.eclipse.sirius.web.compat.services.ImageConstants;
+import org.eclipse.sirius.web.core.api.IObjectService;
+import org.eclipse.sirius.web.forms.components.ListComponent;
+import org.eclipse.sirius.web.forms.description.AbstractControlDescription;
+import org.eclipse.sirius.web.forms.description.FormDescription;
+import org.eclipse.sirius.web.forms.description.GroupDescription;
+import org.eclipse.sirius.web.forms.description.ListDescription;
+import org.eclipse.sirius.web.forms.description.PageDescription;
+import org.eclipse.sirius.web.representations.Failure;
+import org.eclipse.sirius.web.representations.GetOrCreateRandomIdProvider;
+import org.eclipse.sirius.web.representations.IRepresentation;
+import org.eclipse.sirius.web.representations.IStatus;
+import org.eclipse.sirius.web.representations.Success;
+import org.eclipse.sirius.web.representations.VariableManager;
+import org.eclipse.sirius.web.services.api.representations.IRepresentationService;
+import org.eclipse.sirius.web.services.api.representations.RepresentationDescriptor;
+import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
+import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationImageProvider;
+import org.eclipse.sirius.web.spring.collaborative.forms.api.IRepresentationsDescriptionProvider;
+import org.eclipse.sirius.web.spring.collaborative.projects.EditingContextEventProcessor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Used to provide a default form description for the representations representation.
+ *
+ * @author gcoutable
+ */
+@Service
+public class RepresentationsDescriptionProvider implements IRepresentationsDescriptionProvider {
+
+    public static final String REPRESENTATIONS_DEFAULT_FORM_DESCRIPTION_ID = "representations_default_form_description"; //$NON-NLS-1$
+
+    private final IObjectService objectService;
+
+    private final IRepresentationService representationService;
+
+    private final List<IRepresentationImageProvider> representationImageProviders;
+
+    public RepresentationsDescriptionProvider(IObjectService objectService, IRepresentationService representationService, List<IRepresentationImageProvider> representationImageProviders) {
+        this.objectService = Objects.requireNonNull(objectService);
+        this.representationService = Objects.requireNonNull(representationService);
+        this.representationImageProviders = Objects.requireNonNull(representationImageProviders);
+    }
+
+    @Override
+    public FormDescription getRepresentationsDescription() {
+        List<GroupDescription> groupDescriptions = new ArrayList<>();
+        GroupDescription groupDescription = this.getGroupDescription();
+
+        groupDescriptions.add(groupDescription);
+
+        List<PageDescription> pageDescriptions = new ArrayList<>();
+        PageDescription firstPageDescription = this.getPageDescription(groupDescriptions);
+        pageDescriptions.add(firstPageDescription);
+
+        // @formatter:off
+        Function<VariableManager, String> labelProvider = variableManager -> {
+            return Optional.ofNullable(variableManager.getVariables().get(VariableManager.SELF))
+                    .map(this.objectService::getFullLabel)
+                    .orElse("Properties"); //$NON-NLS-1$
+        };
+
+        Function<VariableManager, String> targetObjectIdProvider = variableManager -> variableManager.get(VariableManager.SELF, Object.class)
+                .map(this.objectService::getId)
+                .orElse(null);
+
+        return FormDescription.newFormDescription(UUID.nameUUIDFromBytes(REPRESENTATIONS_DEFAULT_FORM_DESCRIPTION_ID.getBytes()))
+                .label("Representations default form description") //$NON-NLS-1$
+                .idProvider(new GetOrCreateRandomIdProvider())
+                .labelProvider(labelProvider)
+                .targetObjectIdProvider(targetObjectIdProvider)
+                .canCreatePredicate(variableManager -> false)
+                .pageDescriptions(pageDescriptions)
+                .groupDescriptions(groupDescriptions)
+                .build();
+        // @formatter:on
+    }
+
+    private PageDescription getPageDescription(List<GroupDescription> groupDescriptions) {
+        // @formatter:off
+        return PageDescription.newPageDescription("representationPageId") //$NON-NLS-1$
+                .idProvider(variableManager -> "Representations Page") //$NON-NLS-1$
+                .labelProvider(variableManager -> "Representations Page") //$NON-NLS-1$
+                .semanticElementsProvider(variableManager -> Collections.singletonList(variableManager.getVariables().get(VariableManager.SELF)))
+                .groupDescriptions(groupDescriptions)
+                .canCreatePredicate(variableManager -> true)
+                .build();
+        // @formatter:on
+    }
+
+    private GroupDescription getGroupDescription() {
+        List<AbstractControlDescription> controlDescriptions = new ArrayList<>();
+
+        // @formatter:off
+        ListDescription listDescription = ListDescription.newListDescription("RepresentationsList") //$NON-NLS-1$
+            .idProvider(new WidgetIdProvider())
+            .labelProvider((variableManager) -> "Representations") //$NON-NLS-1$
+            .itemsProvider(this.getItemsProvider())
+            .itemIdProvider(this.getItemIdProvider())
+            .itemLabelProvider(this.getItemLabelProvider())
+            .itemImageURLProvider(this.getItemImageURLProvider())
+            .itemDeletableProvider(this.getItemDeletableProvider())
+            .itemDeleteHandlerProvider(this.getItemDeleteHandlerProvider())
+            .itemKindProvider(this.getItemKindProvider())
+            .diagnosticsProvider((variableManager) -> List.of())
+            .kindProvider((object) -> "") //$NON-NLS-1$
+            .messageProvider((object) -> "") //$NON-NLS-1$
+            .build();
+        // @formatter:on
+
+        controlDescriptions.add(listDescription);
+
+        // @formatter:off
+        return GroupDescription.newGroupDescription("representationsGroupId") //$NON-NLS-1$
+                .idProvider(variableManager -> "Representations Group") //$NON-NLS-1$
+                .labelProvider(variableManager -> "Representations Group") //$NON-NLS-1$
+                .semanticElementsProvider(variableManager -> Collections.singletonList(variableManager.getVariables().get(VariableManager.SELF)))
+                .controlDescriptions(controlDescriptions)
+                .build();
+        // @formatter:on
+    }
+
+    private Function<VariableManager, IStatus> getItemDeleteHandlerProvider() {
+        return variableManager -> {
+            // @formatter:off
+            return variableManager.get(ListComponent.CANDIDATE_VARIABLE, RepresentationDescriptor.class)
+                    .map(RepresentationDescriptor::getId)
+                    .map(this::getSuccessStatus)
+                    .orElse(new Failure("")); //$NON-NLS-1$
+            // @formatter:on
+        };
+    }
+
+    private IStatus getSuccessStatus(UUID representationId) {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put(EditingContextEventProcessor.REPRESENTATION_ID, representationId);
+        return new Success(ChangeKind.REPRESENTATION_TO_DELETE, parameters);
+    }
+
+    private Function<VariableManager, Boolean> getItemDeletableProvider() {
+        return variableManager -> {
+            return true;
+        };
+    }
+
+    private Function<VariableManager, String> getItemImageURLProvider() {
+        return variableManager -> {
+            Optional<RepresentationDescriptor> optionalRepresentationDescriptor = variableManager.get(ListComponent.CANDIDATE_VARIABLE, RepresentationDescriptor.class);
+            if (optionalRepresentationDescriptor.isPresent()) {
+                RepresentationDescriptor representationDescriptor = optionalRepresentationDescriptor.get();
+
+                // @formatter:off
+                return this.representationImageProviders.stream()
+                        .map(representationImageProvider -> representationImageProvider.getImageURL(representationDescriptor.getRepresentation()))
+                        .flatMap(Optional::stream)
+                        .findFirst()
+                        .orElse(ImageConstants.RESOURCE_SVG);
+                // @formatter:on
+            }
+            return ImageConstants.DEFAULT_SVG;
+        };
+    }
+
+    private Function<VariableManager, String> getItemLabelProvider() {
+        return variableManager -> {
+            // @formatter:off
+            return variableManager.get(ListComponent.CANDIDATE_VARIABLE, RepresentationDescriptor.class)
+                    .map(RepresentationDescriptor::getLabel)
+                    .orElse(null);
+            // @formatter:on
+        };
+    }
+
+    private Function<VariableManager, String> getItemKindProvider() {
+        return variableManager -> {
+            // @formatter:off
+            return variableManager.get(ListComponent.CANDIDATE_VARIABLE, RepresentationDescriptor.class)
+                    .map(RepresentationDescriptor::getRepresentation)
+                    .map(IRepresentation::getKind)
+                    .orElse(null);
+            // @formatter:on
+        };
+    }
+
+    private Function<VariableManager, String> getItemIdProvider() {
+        return variableManager -> {
+            // @formatter:off
+            return variableManager.get(ListComponent.CANDIDATE_VARIABLE, RepresentationDescriptor.class)
+                    .map(RepresentationDescriptor::getId)
+                    .map(UUID::toString)
+                    .orElse(null);
+            // @formatter:on
+        };
+    }
+
+    private Function<VariableManager, List<Object>> getItemsProvider() {
+        return variableManager -> {
+            Object object = variableManager.getVariables().get(VariableManager.SELF);
+            String id = this.objectService.getId(object);
+            if (id != null) {
+                List<Object> items = new ArrayList<>();
+                items.addAll(this.representationService.getRepresentationDescriptorsForObjectId(id));
+                return items;
+            }
+            return List.of();
+        };
+    }
+}

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/representations/RepresentationsRepresentationRefreshPolicyProvider.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/representations/RepresentationsRepresentationRefreshPolicyProvider.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.sirius.web.services.representations;
+
+import java.util.UUID;
+
+import org.eclipse.sirius.web.representations.IRepresentationDescription;
+import org.eclipse.sirius.web.spring.collaborative.api.ChangeKind;
+import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationRefreshPolicy;
+import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationRefreshPolicyProvider;
+import org.eclipse.sirius.web.spring.collaborative.api.IRepresentationRefreshPolicyRegistry;
+import org.springframework.stereotype.Service;
+
+/**
+ * The representation refresh policy provider for the representation representations.
+ *
+ * @author gcoutable
+ */
+@Service
+public class RepresentationsRepresentationRefreshPolicyProvider implements IRepresentationRefreshPolicyProvider {
+
+    public RepresentationsRepresentationRefreshPolicyProvider(IRepresentationRefreshPolicyRegistry representationRefreshPolicyRegistry) {
+        representationRefreshPolicyRegistry.add(this);
+    }
+
+    @Override
+    public boolean canHandle(IRepresentationDescription representationDescription) {
+        return UUID.nameUUIDFromBytes(RepresentationsDescriptionProvider.REPRESENTATIONS_DEFAULT_FORM_DESCRIPTION_ID.getBytes()).equals(representationDescription.getId());
+    }
+
+    @Override
+    public IRepresentationRefreshPolicy getRepresentationRefreshPolicy(IRepresentationDescription representationDescription) {
+        return (changeDescription) -> {
+            boolean shouldRefresh = false;
+
+            switch (changeDescription.getKind()) {
+            case ChangeKind.REPRESENTATION_CREATION:
+                shouldRefresh = true;
+                break;
+            case ChangeKind.REPRESENTATION_DELETION:
+                shouldRefresh = true;
+                break;
+            case ChangeKind.REPRESENTATION_RENAMING:
+                shouldRefresh = true;
+                break;
+            case ChangeKind.REPRESENTATION_TO_DELETE:
+                shouldRefresh = true;
+                break;
+            default:
+                shouldRefresh = false;
+            }
+            return shouldRefresh;
+        };
+    }
+
+}

--- a/backend/sirius-web-spring/pom.xml
+++ b/backend/sirius-web-spring/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.1</sirius.components.version>
+		<sirius.components.version>0.5.2</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/backend/sirius-web-spring/pom.xml
+++ b/backend/sirius-web-spring/pom.xml
@@ -31,7 +31,7 @@
 
 	<properties>
 		<java.version>11</java.version>
-		<sirius.components.version>0.5.2</sirius.components.version>
+		<sirius.components.version>0.5.3</sirius.components.version>
 	</properties>
 
 	<repositories>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@apollo/client": "3.4.7",
-        "@eclipse-sirius/sirius-components": "0.5.1",
+        "@eclipse-sirius/sirius-components": "0.5.2",
         "@material-ui/core": "4.12.3",
         "@material-ui/icons": "4.11.2",
         "@xstate/react": "1.5.1",
@@ -3445,9 +3445,9 @@
       "dev": true
     },
     "node_modules/@eclipse-sirius/sirius-components": {
-      "version": "0.5.1",
-      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.5.1/818f5bda4a908f5f404b3962b6617f406a010692a8db91d9b674a3ae34dbb4f1",
-      "integrity": "sha512-t/SdMF+H7RrIKPhlSf3WrV755lJnGeJahd4KWTusQ+pP1i8C0EoUX7LmN6CxJZiJyH62nn8ZbqIoXv6pgau3DA==",
+      "version": "0.5.2",
+      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.5.2/632ff85561ac429b94668255b834a1ca379fb72e439c04918af9b11830124074",
+      "integrity": "sha512-zE+zSPgRiRD6+Yln0NmTsBgbmEJ8VgZLkcJ/iA/RvuULw28RV8xS2b9Me9pjITr4P73i7bn/yJ8zje+lJryHOw==",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"
@@ -28144,9 +28144,9 @@
       "dev": true
     },
     "@eclipse-sirius/sirius-components": {
-      "version": "0.5.1",
-      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.5.1/818f5bda4a908f5f404b3962b6617f406a010692a8db91d9b674a3ae34dbb4f1",
-      "integrity": "sha512-t/SdMF+H7RrIKPhlSf3WrV755lJnGeJahd4KWTusQ+pP1i8C0EoUX7LmN6CxJZiJyH62nn8ZbqIoXv6pgau3DA==",
+      "version": "0.5.2",
+      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.5.2/632ff85561ac429b94668255b834a1ca379fb72e439c04918af9b11830124074",
+      "integrity": "sha512-zE+zSPgRiRD6+Yln0NmTsBgbmEJ8VgZLkcJ/iA/RvuULw28RV8xS2b9Me9pjITr4P73i7bn/yJ8zje+lJryHOw==",
       "requires": {
         "uuid": "8.3.2"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@apollo/client": "3.4.7",
-        "@eclipse-sirius/sirius-components": "0.5.2",
+        "@eclipse-sirius/sirius-components": "0.5.3",
         "@material-ui/core": "4.12.3",
         "@material-ui/icons": "4.11.2",
         "@xstate/react": "1.5.1",
@@ -3445,9 +3445,9 @@
       "dev": true
     },
     "node_modules/@eclipse-sirius/sirius-components": {
-      "version": "0.5.2",
-      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.5.2/632ff85561ac429b94668255b834a1ca379fb72e439c04918af9b11830124074",
-      "integrity": "sha512-zE+zSPgRiRD6+Yln0NmTsBgbmEJ8VgZLkcJ/iA/RvuULw28RV8xS2b9Me9pjITr4P73i7bn/yJ8zje+lJryHOw==",
+      "version": "0.5.3",
+      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.5.3/a54ef0616cd96cc64e7ebd3c1d02a6ebef818f9c44b8638b4f34ad4eb4d4aa03",
+      "integrity": "sha512-c/yPrQTLnGkbkQUa4oR8NXdlf1Pe0b/aS0ZAEXSHXckENclzOap4JqwOe9AjPjbiPpHeRmAaEL7JcVrCRwIPqQ==",
       "license": "EPL-2.0",
       "dependencies": {
         "uuid": "8.3.2"
@@ -28144,9 +28144,9 @@
       "dev": true
     },
     "@eclipse-sirius/sirius-components": {
-      "version": "0.5.2",
-      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.5.2/632ff85561ac429b94668255b834a1ca379fb72e439c04918af9b11830124074",
-      "integrity": "sha512-zE+zSPgRiRD6+Yln0NmTsBgbmEJ8VgZLkcJ/iA/RvuULw28RV8xS2b9Me9pjITr4P73i7bn/yJ8zje+lJryHOw==",
+      "version": "0.5.3",
+      "resolved": "https://npm.pkg.github.com/download/@eclipse-sirius/sirius-components/0.5.3/a54ef0616cd96cc64e7ebd3c1d02a6ebef818f9c44b8638b4f34ad4eb4d4aa03",
+      "integrity": "sha512-c/yPrQTLnGkbkQUa4oR8NXdlf1Pe0b/aS0ZAEXSHXckENclzOap4JqwOe9AjPjbiPpHeRmAaEL7JcVrCRwIPqQ==",
       "requires": {
         "uuid": "8.3.2"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
   "proxy": "http://localhost:8080",
   "dependencies": {
     "@apollo/client": "3.4.7",
-    "@eclipse-sirius/sirius-components": "0.5.2",
+    "@eclipse-sirius/sirius-components": "0.5.3",
     "@material-ui/core": "4.12.3",
     "@material-ui/icons": "4.11.2",
     "@xstate/react": "1.5.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
   "proxy": "http://localhost:8080",
   "dependencies": {
     "@apollo/client": "3.4.7",
-    "@eclipse-sirius/sirius-components": "0.5.1",
+    "@eclipse-sirius/sirius-components": "0.5.2",
     "@material-ui/core": "4.12.3",
     "@material-ui/icons": "4.11.2",
     "@xstate/react": "1.5.1",

--- a/scripts/upgrade-sirius-web.sh
+++ b/scripts/upgrade-sirius-web.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate patches for `sirius-web` in the range `HEAD..origin/master` and
+# apply them in the main repository.
+
+# https://stackoverflow.com/a/246128/4874344
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+repo_dir=$(realpath "$script_dir/..")
+
+submodule_directory=sirius-web
+
+pushd "$repo_dir" >/dev/null
+pushd "$submodule_directory" >/dev/null
+
+existing_patch_files=$(ls ./*.patch 2>/dev/null || true)
+
+if [[ -n "$existing_patch_files" ]]; then
+	echo "There are existing patch files (*.patch) in the $submodule_directory"
+	echo "Clean them up and start again"
+	exit 1
+fi
+
+echo "Fetching $submodule_directory upstream commits"
+git fetch
+upstream_tip_rev=origin/master
+upstream_tip_hash=$(git rev-parse "$upstream_tip_rev")
+
+commits_to_upstream_tip=$(git rev-list "..$upstream_tip_hash")
+
+if [ -z "$commits_to_upstream_tip" ]; then
+	echo "Nothing to upgrade. Already up-to-date"
+	echo "$upstream_tip_rev is at $upstream_tip_hash"
+	exit 0
+fi
+
+commits_to_upstream_tip_count=$(wc -l <<<"$commits_to_upstream_tip")
+echo "Upgrading $commits_to_upstream_tip_count commit(s) to $upstream_tip_rev ($upstream_tip_hash)"
+
+echo "Generating patch files"
+git format-patch "..$upstream_tip_hash"
+echo "Generated patch files. Applying them in the main repository"
+popd >/dev/null
+if ! git am -3 $submodule_directory/*.patch; then
+	echo ""
+	echo "Could not cleanly apply patches. You are on your own now"
+	echo "Use 'git status' for guidance"
+	echo "Do not forget to remove generated patches in the $submodule_directory directory"
+	echo "and point that submodule tip to $upstream_tip_rev ($upstream_tip_hash)"
+	exit 2
+fi
+
+echo "Cleaning up generated patches"
+pushd "$submodule_directory" >/dev/null
+rm ./*.patch
+
+echo "Updating $submodule_directory tip to $upstream_tip_rev ($upstream_tip_hash)"
+git pull "$upstream_tip_hash"
+
+echo "Done, upgraded $commits_to_upstream_tip_count commits"

--- a/scripts/upgrade-sirius-web.sh
+++ b/scripts/upgrade-sirius-web.sh
@@ -47,6 +47,12 @@ if ! git am -3 $submodule_directory/*.patch; then
 	echo "Use 'git status' for guidance"
 	echo "Do not forget to remove generated patches in the $submodule_directory directory"
 	echo "and point that submodule tip to $upstream_tip_rev ($upstream_tip_hash)"
+
+	echo "HINT:"
+	echo "If you saw an error starting with:"
+	echo "  error: sha1 information is lacking or useless"
+	echo "  error: could not build fake ancestor"
+	echo "Make sure you have the upstream repository added as a remote in the main repository"
 	exit 2
 fi
 


### PR DESCRIPTION
Pull in the 2 upstream commits and change the submodule so it points to 3f7428790e5719b7f288a50db98f0a777ad50535

Since I feel pulling changes from the upstream will be pretty common, I added a script to automate the process. If we are lucky and patches apply cleanly, it fully automates the process. If there are patch conflicts, there are some manual steps to complete.

I had a problem that the patches could not be applied:

```sh
19:19 $ ./scripts/upgrade-sirius-web.sh
Fetching sirius-web upstream commits
Upgrading 2 commit(s) to origin/master (3f7428790e5719b7f288a50db98f0a777ad50535)
Generating patch files
0001-130-Add-support-for-unsynchronized-Flow-diagrams-wit.patch
0002-694-Add-the-support-for-the-representation-represent.patch
Generated patch files. Applying them in the main repository
Applying: Add support for unsynchronized Flow diagrams with Sirius Components 0.5.2
error: sha1 information is lacking or useless (backend/sirius-web-frontend/pom.xml).
error: could not build fake ancestor
Patch failed at 0001 Add support for unsynchronized Flow diagrams with Sirius Components 0.5.2
hint: Use 'git am --show-current-patch' to see the failed patch
When you have resolved this problem, run "git am --continue".
If you prefer to skip this patch, run "git am --skip" instead.
To restore the original branch and stop patching, run "git am --abort".
```

This is because I didn't have https://github.com/eclipse-sirius/sirius-web added as a remote in the main repository and git did not recognize the commit hashes to find common ancestors. Adding in https://github.com/eclipse-sirius/sirius-web as a remote fixed the problem:

```sh
git remote add upstream git@github.com:eclipse-sirius/sirius-web.git
git fetch upstream
```