### PR TITLE
Add UI for the BalticLSC toolbox entries

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@material-ui/icons": "4.11.2",
         "@xstate/react": "1.5.1",
         "fontsource-roboto": "4.0.0",
+        "fp-ts": "^2.11.5",
         "graphql": "15.5.1",
         "graphql-tag": "2.12.5",
         "graphql.macro": "1.4.2",
@@ -11771,6 +11772,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fp-ts": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.11.5.tgz",
+      "integrity": "sha512-OqlwJq1BdpB83BZXTqI+dNcA6uYk6qk4u9Cgnt64Y+XS7dwdbp/mobx8S2KXf2AXH+scNmA/UVK3SEFHR3vHZA=="
     },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
@@ -34691,6 +34697,11 @@
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true
+    },
+    "fp-ts": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.11.5.tgz",
+      "integrity": "sha512-OqlwJq1BdpB83BZXTqI+dNcA6uYk6qk4u9Cgnt64Y+XS7dwdbp/mobx8S2KXf2AXH+scNmA/UVK3SEFHR3vHZA=="
     },
     "fragment-cache": {
       "version": "0.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "@material-ui/icons": "4.11.2",
     "@xstate/react": "1.5.1",
     "fontsource-roboto": "4.0.0",
+    "fp-ts": "^2.11.5",
     "graphql": "15.5.1",
     "graphql-tag": "2.12.5",
     "graphql.macro": "1.4.2",

--- a/frontend/src/views/edit-project/EditProjectView.tsx
+++ b/frontend/src/views/edit-project/EditProjectView.tsx
@@ -39,10 +39,9 @@ import {
   HandleFetchedProjectEvent,
   HideToastEvent,
   SchemaValue,
-  SelectRepresentationEvent,
   ShowToastEvent,
-} from "views/edit-project/EditProjectViewMachine";
-import { Representation, Workbench } from "@eclipse-sirius/sirius-components";
+} from "./EditProjectViewMachine";
+import { Workbench } from "./Workbench";
 import { NavigationBar } from "navigationBar/NavigationBar";
 
 const getProjectQuery = gql`
@@ -68,7 +67,7 @@ const getProjectQuery = gql`
   }
 `;
 
-const useEditProjectViewStyles = makeStyles((theme) => ({
+const useEditProjectViewStyles = makeStyles(() => ({
   editProjectView: {
     display: "grid",
     gridTemplateRows: "min-content minmax(0, 1fr)",
@@ -160,22 +159,10 @@ export const EditProjectView = () => {
 
   let main = null;
   if (editProjectView === "loaded" && project) {
-    const onRepresentationSelected = (
-      representationSelected: Representation
-    ) => {
-      const selectRepresentationEvent: SelectRepresentationEvent = {
-        type: "SELECT_REPRESENTATION",
-        representation: representationSelected,
-      };
-      dispatch(selectRepresentationEvent);
-    };
-
     main = (
       <Workbench
         editingContextId={project.currentEditingContext.id}
-        initialRepresentationSelected={representation}
-        onRepresentationSelected={onRepresentationSelected}
-        readOnly={false}
+        representation={representation}
       />
     );
   } else if (editProjectView === "missing") {

--- a/frontend/src/views/edit-project/EditProjectView.tsx
+++ b/frontend/src/views/edit-project/EditProjectView.tsx
@@ -143,20 +143,6 @@ export const EditProjectView = () => {
     representationId,
   ]);
 
-  useEffect(() => {
-    const toolboxUrl = `${process.env.REACT_APP_BALTICLSC_API_URL}/backend/dev/toolbox/`;
-    fetch(toolboxUrl, {
-      headers: {
-        authorization:
-          "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6ImRlbW8iLCJzdWIiOiJkZW1vIiwianRpIjoiYjQ5ZTJjZmQ0ZGQ5NDM1ODk1OTEwNmY0ZjcwNWY0YTciLCJzaWQiOiJiYjdhNTNhMjA1ZDM0NWY4YmNlYWRhYWEwZjkxZjhiNyIsImV4cCI6MTYzNjQwMzA3MywiaXNzIjoid3V0LmJhbHRpY2xzYy5ldSIsImF1ZCI6Ind1dC5iYWx0aWNsc2MuZXUifQ.RXUVe-i4_6TFdtbp1SYCB0yPowcX75bT59cd_ddrGt0",
-      },
-    })
-      .then((r) => r.json())
-      .then((response) => {
-        console.log("Got toolbox", response);
-      });
-  }, []);
-
   let main = null;
   if (editProjectView === "loaded" && project) {
     main = (

--- a/frontend/src/views/edit-project/EditProjectView.tsx
+++ b/frontend/src/views/edit-project/EditProjectView.tsx
@@ -46,22 +46,21 @@ import { Representation, Workbench } from "@eclipse-sirius/sirius-components";
 import { NavigationBar } from "navigationBar/NavigationBar";
 
 const getProjectQuery = gql`
-  query getRepresentation(
-    $projectId: ID!
-    $representationId: ID!
-    $includeRepresentation: Boolean!
-  ) {
+  query getRepresentation($projectId: ID!) {
     viewer {
       project(projectId: $projectId) {
         id
         name
         currentEditingContext {
           id
-          representation(representationId: $representationId)
-            @include(if: $includeRepresentation) {
-            id
-            label
-            kind
+          representations {
+            edges {
+              node {
+                id
+                kind
+                label
+              }
+            }
           }
         }
       }
@@ -97,8 +96,6 @@ export const EditProjectView = () => {
   >(getProjectQuery, {
     variables: {
       projectId,
-      representationId: representationId ?? "",
-      includeRepresentation: !!representationId,
     },
   });
   useEffect(() => {

--- a/frontend/src/views/edit-project/EditProjectView.types.ts
+++ b/frontend/src/views/edit-project/EditProjectView.types.ts
@@ -27,9 +27,13 @@ export type GQLRepresentation = {
   kind: string;
 };
 
+export interface GQLConnection<T> {
+  edges: { node: T }[];
+}
+
 export type GQLEditingContext = {
   id: string;
-  representation: GQLRepresentation | undefined;
+  representations: GQLConnection<GQLRepresentation>;
 };
 
 export type GQLProject = {
@@ -48,8 +52,6 @@ export type GQLGetProjectQueryData = {
 
 export type GQLGetProjectQueryVariables = {
   projectId: string;
-  representationId: string;
-  includeRepresentation: boolean;
 };
 
 export interface EditProjectViewParams {

--- a/frontend/src/views/edit-project/Workbench/LeftSite.tsx
+++ b/frontend/src/views/edit-project/Workbench/LeftSite.tsx
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { ExplorerWebSocketContainer } from "@eclipse-sirius/sirius-components";
+import MuiAccordion from "@material-ui/core/Accordion";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
+import MuiAccordionSummary from "@material-ui/core/AccordionSummary";
+import MuiCollapse from "@material-ui/core/Collapse";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import React from "react";
+import { LeftSiteProps } from "./LeftSite.types";
+import { ValidationWebSocketContainer } from "./validation";
+
+const useSiteStyles = makeStyles(() => ({
+  site: {
+    display: "grid",
+    gridTemplateColumns: "minmax(0,1fr)",
+  },
+  bothExpanded: {
+    gridTemplateRows: "minmax(0,1fr) minmax(0,1fr)",
+  },
+  noneExpanded: {
+    gridTemplateRows: "min-content min-content",
+  },
+  explorerExpandedOnly: {
+    gridTemplateRows: "minmax(0,1fr) min-content",
+  },
+  validationExpandedOnly: {
+    gridTemplateRows: "min-content minmax(0,1fr)",
+  },
+}));
+
+const Accordion = withStyles({
+  root: {
+    display: "grid",
+    gridTemplateColumns: "minmax(0,1fr)",
+    gridTemplateRows: "min-content minmax(0,1fr)",
+    border: "1px solid rgba(0, 0, 0, .125)",
+    boxShadow: "none",
+    "&:not(:last-child)": {
+      borderBottom: "0px",
+    },
+    "&:before": {
+      display: "none",
+    },
+    "&$expanded": {
+      margin: "0px",
+    },
+  },
+  expanded: {},
+})(MuiAccordion);
+
+const AccordionSummary = withStyles({
+  root: {
+    borderBottom: "1px solid rgba(0, 0, 0, .125)",
+    marginBottom: -1,
+    "&$expanded": {
+      minHeight: 48,
+    },
+  },
+  content: {
+    "&$expanded": {
+      margin: "0px",
+    },
+  },
+  expanded: {},
+})(MuiAccordionSummary);
+
+const CustomCollapse = withStyles({
+  entered: {
+    overflow: "auto",
+  },
+})(MuiCollapse);
+
+export const LeftSite = ({
+  editingContextId,
+  setSelection,
+  selection,
+  readOnly,
+}: LeftSiteProps) => {
+  const classes = useSiteStyles();
+
+  const [explorerExpanded, setExplorerExpanded] = React.useState<boolean>(true);
+  const [validationExpanded, setValidationExpanded] =
+    React.useState<boolean>(true);
+
+  let classSite = classes.site;
+  if (explorerExpanded && validationExpanded) {
+    classSite = `${classSite} ${classes.bothExpanded}`;
+  }
+  if (!explorerExpanded && !validationExpanded) {
+    classSite = `${classSite} ${classes.noneExpanded}`;
+  }
+  if (explorerExpanded && !validationExpanded) {
+    classSite = `${classSite} ${classes.explorerExpandedOnly}`;
+  }
+  if (!explorerExpanded && validationExpanded) {
+    classSite = `${classSite} ${classes.validationExpandedOnly}`;
+  }
+
+  return (
+    <div className={classSite}>
+      <Accordion
+        square
+        expanded={explorerExpanded}
+        onChange={(event, isExpanded) => setExplorerExpanded(isExpanded)}
+        TransitionComponent={CustomCollapse as any}
+      >
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          Explorer
+        </AccordionSummary>
+        <AccordionDetails>
+          <ExplorerWebSocketContainer
+            editingContextId={editingContextId}
+            setSelection={setSelection}
+            selection={selection}
+            readOnly={readOnly}
+          />
+        </AccordionDetails>
+      </Accordion>
+      <Accordion
+        square
+        expanded={validationExpanded}
+        onChange={(event, isExpanded) => setValidationExpanded(isExpanded)}
+        TransitionComponent={CustomCollapse as any}
+      >
+        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+          Validation
+        </AccordionSummary>
+        <AccordionDetails>
+          <ValidationWebSocketContainer editingContextId={editingContextId} />
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  );
+};

--- a/frontend/src/views/edit-project/Workbench/LeftSite.types.ts
+++ b/frontend/src/views/edit-project/Workbench/LeftSite.types.ts
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { Selection } from "@eclipse-sirius/sirius-components";
+
+export interface LeftSiteProps {
+  editingContextId: string;
+  selection?: Selection;
+  setSelection: (selection: Selection) => void;
+  readOnly: boolean;
+}

--- a/frontend/src/views/edit-project/Workbench/Panels/Panels.module.css
+++ b/frontend/src/views/edit-project/Workbench/Panels/Panels.module.css
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+.panel {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.verticalResizer {
+  width: 4px;
+  cursor: col-resize;
+  display: grid;
+}
+.horizontalResizer {
+  height: 4px;
+  cursor: row-resize;
+  display: grid;
+}
+
+.verticalResizer div {
+  background-color: var(--daintree-lighten-80);
+  border-color: var(--daintree-lighten-70);
+  border-right-style: solid;
+  border-right-width: 1px;
+  margin-right: 1px;
+}
+
+.horizontalResizer div {
+  background-color: var(--daintree-lighten-80);
+  border-color: var(--daintree-lighten-70);
+  border-top-style: solid;
+  border-top-width: 1px;
+  margin-top: 1px;
+}

--- a/frontend/src/views/edit-project/Workbench/Panels/Panels.tsx
+++ b/frontend/src/views/edit-project/Workbench/Panels/Panels.tsx
@@ -1,0 +1,142 @@
+/**
+ * Copied from
+ * @see https://github.com/eclipse-sirius/sirius-components/blob/master/frontend/src/core/panels/Panels.tsx
+ *
+ * The component is used to recreate `Workbench` from `sirius-components`. `Panels` were not exported as public API.
+ * @see https://github.com/eclipse-sirius/sirius-components/issues/830#issuecomment-967976773
+ */
+
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import PropTypes from "prop-types";
+import { MouseEventHandler, useState } from "react";
+import styles from "./Panels.module.css";
+
+export const HORIZONTAL = "HORIZONTAL";
+export const VERTICAL = "VERTICAL";
+
+export const FIRST_PANEL = "FIRST_PANEL";
+export const SECOND_PANEL = "SECOND_PANEL";
+
+const propTypes = {
+  orientation: PropTypes.oneOf([HORIZONTAL, VERTICAL]),
+  resizablePanel: PropTypes.oneOf([FIRST_PANEL, SECOND_PANEL]),
+  initialResizablePanelSize: PropTypes.number.isRequired,
+};
+const defaultProps = {
+  orientation: HORIZONTAL,
+  resizablePanel: FIRST_PANEL,
+};
+
+export const Panels = ({
+  firstPanel,
+  secondPanel,
+  orientation,
+  resizablePanel,
+  initialResizablePanelSize,
+}) => {
+  const initialState = {
+    isDragging: false,
+    initialPosition: 0,
+    resizablePanelSize: initialResizablePanelSize,
+  };
+  const [state, setState] = useState(initialState);
+  const { isDragging, resizablePanelSize } = state;
+
+  const startResize: MouseEventHandler = (event) => {
+    let initialPosition = event.clientX;
+    if (orientation === VERTICAL) {
+      initialPosition = event.clientY;
+    }
+    setState((prevState) => {
+      return {
+        isDragging: true,
+        initialPosition,
+        resizablePanelSize: prevState.resizablePanelSize,
+      };
+    });
+  };
+
+  const resizePanel: MouseEventHandler = (event) => {
+    if (isDragging) {
+      let initialPosition = event.clientX;
+      if (orientation === VERTICAL) {
+        initialPosition = event.clientY;
+      }
+      setState((prevState) => {
+        const delta = initialPosition - prevState.initialPosition;
+        let resizablePanelSize = prevState.resizablePanelSize + delta;
+        if (resizablePanel === SECOND_PANEL) {
+          resizablePanelSize = prevState.resizablePanelSize - delta;
+        }
+        return { ...prevState, initialPosition, resizablePanelSize };
+      });
+    }
+  };
+
+  const stopResize = () => {
+    if (isDragging) {
+      setState((prevState) => {
+        return { ...prevState, isDragging: false, initialPosition: 0 };
+      });
+    }
+  };
+
+  let style = {
+    display: "grid",
+    gridTemplateRows: "minmax(0, 1fr)",
+    gridTemplateColumns: `${resizablePanelSize}px min-content minmax(0, 1fr)`,
+  };
+  if (resizablePanel === SECOND_PANEL) {
+    style = {
+      display: "grid",
+      gridTemplateRows: "minmax(0, 1fr)",
+      gridTemplateColumns: `minmax(0, 1fr) min-content ${resizablePanelSize}px`,
+    };
+  }
+  if (orientation === VERTICAL) {
+    style = {
+      display: "grid",
+      gridTemplateRows: `${resizablePanelSize}px min-content minmax(0, 1fr)`,
+      gridTemplateColumns: "minmax(0, 1fr)",
+    };
+    if (resizablePanel === SECOND_PANEL) {
+      style = {
+        display: "grid",
+        gridTemplateRows: `minmax(0, 1fr) min-content ${resizablePanelSize}px`,
+        gridTemplateColumns: "minmax(0, 1fr)",
+      };
+    }
+  }
+
+  let resizerClassName = styles.verticalResizer;
+  if (orientation === VERTICAL) {
+    resizerClassName = styles.horizontalResizer;
+  }
+  return (
+    <div
+      style={style}
+      onMouseMove={resizePanel}
+      onMouseUp={stopResize}
+      onMouseLeave={stopResize}
+    >
+      <div className={styles.panel}>{firstPanel}</div>
+      <div className={resizerClassName} onMouseDown={startResize}>
+        <div />
+      </div>
+      <div className={styles.panel}>{secondPanel}</div>
+    </div>
+  );
+};
+Panels.propTypes = propTypes;
+Panels.defaultProps = defaultProps;

--- a/frontend/src/views/edit-project/Workbench/Panels/index.ts
+++ b/frontend/src/views/edit-project/Workbench/Panels/index.ts
@@ -1,0 +1,1 @@
+export * from "./Panels";

--- a/frontend/src/views/edit-project/Workbench/RightSite.tsx
+++ b/frontend/src/views/edit-project/Workbench/RightSite.tsx
@@ -11,101 +11,21 @@
  *     Obeo - initial API and implementation
  *******************************************************************************/
 
-import MuiAccordion from "@material-ui/core/Accordion";
-import AccordionDetails from "@material-ui/core/AccordionDetails";
-import MuiAccordionSummary from "@material-ui/core/AccordionSummary";
-import MuiCollapse, { CollapseProps } from "@material-ui/core/Collapse";
-import { makeStyles, withStyles } from "@material-ui/core/styles";
-import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import { makeStyles } from "@material-ui/core/styles";
 import { PropertiesWebSocketContainer } from "@eclipse-sirius/sirius-components";
-import { useState } from "react";
 import { RightSiteProps } from "./RightSite.types";
+import Typography from "@material-ui/core/Typography";
 
-// TODO: remove Representations panel leftovers
-
-const useSiteStyles = makeStyles(() => ({
+const useSiteStyles = makeStyles((theme) => ({
   site: {
     display: "grid",
     gridTemplateColumns: "minmax(0,1fr)",
+    gridTemplateRows: "minmax(0,1fr)",
   },
-  detailsExpanded: {
-    gridTemplateRows: "minmax(0,1fr) min-content",
-  },
-  representationsExpanded: {
-    gridTemplateRows: "min-content minmax(0,1fr)",
-  },
-  accordionDetailsRoot: {
-    display: "block",
+  detailsHeading: {
+    margin: theme.spacing(1, 1, 0),
   },
 }));
-
-const Accordion = withStyles({
-  root: {
-    display: "grid",
-    gridTemplateColumns: "minmax(0,1fr)",
-    gridTemplateRows: "min-content minmax(0,1fr)",
-    border: "1px solid rgba(0, 0, 0, .125)",
-    boxShadow: "none",
-    "&:not(:last-child)": {
-      borderBottom: "0px",
-    },
-    "&:before": {
-      display: "none",
-    },
-    "&$expanded": {
-      margin: "0px",
-    },
-  },
-  expanded: {},
-})(MuiAccordion);
-
-const AccordionSummary = withStyles({
-  root: {
-    borderBottom: "1px solid rgba(0, 0, 0, .125)",
-    marginBottom: -1,
-    "&$expanded": {
-      minHeight: 48,
-    },
-  },
-  content: {
-    "&$expanded": {
-      margin: "0px",
-    },
-  },
-  expanded: {},
-})(MuiAccordionSummary);
-
-const StyledCollapse = withStyles({
-  entered: {
-    overflow: "auto",
-  },
-})(MuiCollapse);
-
-const CustomCollapse = (props: CollapseProps) => {
-  const { children, ...collapseProps } = props;
-
-  const handleEntering = (node: HTMLElement, isAppearing: boolean) => {
-    node.style.height = "auto";
-  };
-
-  const handleExit = (node: HTMLElement) => {
-    node.style.height = "auto";
-  };
-
-  return (
-    <StyledCollapse
-      {...collapseProps}
-      onEntering={handleEntering}
-      onExit={handleExit}
-      timeout={0}
-    >
-      {children}
-    </StyledCollapse>
-  );
-};
-
-const DETAILS_PANEL_NAME = "details";
-const REPRESENTATIONS_PANEL_NAME = "representations";
 
 export const RightSite = ({
   editingContextId,
@@ -115,45 +35,20 @@ export const RightSite = ({
 }: RightSiteProps) => {
   const classes = useSiteStyles();
 
-  const [expanded, setExpanded] = useState<string>(DETAILS_PANEL_NAME);
-
-  const handleChange = (panel: string) => () => {
-    setExpanded(panel);
-  };
-
-  let classSite = classes.site;
-  if (expanded === DETAILS_PANEL_NAME) {
-    classSite = `${classSite} ${classes.detailsExpanded}`;
-  } else if (expanded === REPRESENTATIONS_PANEL_NAME) {
-    classSite = `${classSite} ${classes.representationsExpanded}`;
-  }
-
   return (
-    <div className={classSite}>
-      <Accordion
-        square
-        expanded={expanded === DETAILS_PANEL_NAME}
-        onChange={handleChange(DETAILS_PANEL_NAME)}
-        TransitionComponent={CustomCollapse}
-      >
-        <AccordionSummary
-          expandIcon={<ExpandMoreIcon />}
-          IconButtonProps={{ size: "small" }}
-        >
+    <div className={classes.site}>
+      <div>
+        <Typography variant="h6" className={classes.detailsHeading}>
           Details
-        </AccordionSummary>
-        <AccordionDetails
-          className={classes.accordionDetailsRoot}
-          data-testid={"Details AccordionDetails"}
-        >
-          <PropertiesWebSocketContainer
-            editingContextId={editingContextId}
-            selection={selection}
-            setSelection={setSelection}
-            readOnly={readOnly}
-          />
-        </AccordionDetails>
-      </Accordion>
+        </Typography>
+
+        <PropertiesWebSocketContainer
+          editingContextId={editingContextId}
+          selection={selection}
+          setSelection={setSelection}
+          readOnly={readOnly}
+        />
+      </div>
     </div>
   );
 };

--- a/frontend/src/views/edit-project/Workbench/RightSite.tsx
+++ b/frontend/src/views/edit-project/Workbench/RightSite.tsx
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import MuiAccordion from "@material-ui/core/Accordion";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
+import MuiAccordionSummary from "@material-ui/core/AccordionSummary";
+import MuiCollapse, { CollapseProps } from "@material-ui/core/Collapse";
+import { makeStyles, withStyles } from "@material-ui/core/styles";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import { PropertiesWebSocketContainer } from "@eclipse-sirius/sirius-components";
+import { useState } from "react";
+import { RightSiteProps } from "./RightSite.types";
+
+// TODO: remove Representations panel leftovers
+
+const useSiteStyles = makeStyles(() => ({
+  site: {
+    display: "grid",
+    gridTemplateColumns: "minmax(0,1fr)",
+  },
+  detailsExpanded: {
+    gridTemplateRows: "minmax(0,1fr) min-content",
+  },
+  representationsExpanded: {
+    gridTemplateRows: "min-content minmax(0,1fr)",
+  },
+  accordionDetailsRoot: {
+    display: "block",
+  },
+}));
+
+const Accordion = withStyles({
+  root: {
+    display: "grid",
+    gridTemplateColumns: "minmax(0,1fr)",
+    gridTemplateRows: "min-content minmax(0,1fr)",
+    border: "1px solid rgba(0, 0, 0, .125)",
+    boxShadow: "none",
+    "&:not(:last-child)": {
+      borderBottom: "0px",
+    },
+    "&:before": {
+      display: "none",
+    },
+    "&$expanded": {
+      margin: "0px",
+    },
+  },
+  expanded: {},
+})(MuiAccordion);
+
+const AccordionSummary = withStyles({
+  root: {
+    borderBottom: "1px solid rgba(0, 0, 0, .125)",
+    marginBottom: -1,
+    "&$expanded": {
+      minHeight: 48,
+    },
+  },
+  content: {
+    "&$expanded": {
+      margin: "0px",
+    },
+  },
+  expanded: {},
+})(MuiAccordionSummary);
+
+const StyledCollapse = withStyles({
+  entered: {
+    overflow: "auto",
+  },
+})(MuiCollapse);
+
+const CustomCollapse = (props: CollapseProps) => {
+  const { children, ...collapseProps } = props;
+
+  const handleEntering = (node: HTMLElement, isAppearing: boolean) => {
+    node.style.height = "auto";
+  };
+
+  const handleExit = (node: HTMLElement) => {
+    node.style.height = "auto";
+  };
+
+  return (
+    <StyledCollapse
+      {...collapseProps}
+      onEntering={handleEntering}
+      onExit={handleExit}
+      timeout={0}
+    >
+      {children}
+    </StyledCollapse>
+  );
+};
+
+const DETAILS_PANEL_NAME = "details";
+const REPRESENTATIONS_PANEL_NAME = "representations";
+
+export const RightSite = ({
+  editingContextId,
+  selection,
+  setSelection,
+  readOnly,
+}: RightSiteProps) => {
+  const classes = useSiteStyles();
+
+  const [expanded, setExpanded] = useState<string>(DETAILS_PANEL_NAME);
+
+  const handleChange = (panel: string) => () => {
+    setExpanded(panel);
+  };
+
+  let classSite = classes.site;
+  if (expanded === DETAILS_PANEL_NAME) {
+    classSite = `${classSite} ${classes.detailsExpanded}`;
+  } else if (expanded === REPRESENTATIONS_PANEL_NAME) {
+    classSite = `${classSite} ${classes.representationsExpanded}`;
+  }
+
+  return (
+    <div className={classSite}>
+      <Accordion
+        square
+        expanded={expanded === DETAILS_PANEL_NAME}
+        onChange={handleChange(DETAILS_PANEL_NAME)}
+        TransitionComponent={CustomCollapse}
+      >
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          IconButtonProps={{ size: "small" }}
+        >
+          Details
+        </AccordionSummary>
+        <AccordionDetails
+          className={classes.accordionDetailsRoot}
+          data-testid={"Details AccordionDetails"}
+        >
+          <PropertiesWebSocketContainer
+            editingContextId={editingContextId}
+            selection={selection}
+            setSelection={setSelection}
+            readOnly={readOnly}
+          />
+        </AccordionDetails>
+      </Accordion>
+    </div>
+  );
+};

--- a/frontend/src/views/edit-project/Workbench/RightSite.types.ts
+++ b/frontend/src/views/edit-project/Workbench/RightSite.types.ts
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { Selection } from "@eclipse-sirius/sirius-components";
+
+export interface RightSiteProps {
+  editingContextId: string;
+  selection: Selection;
+  setSelection: (selection: Selection) => void;
+  readOnly: boolean;
+}

--- a/frontend/src/views/edit-project/Workbench/Toolbox/Toolbox.tsx
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/Toolbox.tsx
@@ -114,7 +114,7 @@ export const Toolbox = ({ editingContextId }: ToolboxProps) => {
   if (error) {
     return <div>Cannot load toolbox: {error.message}</div>;
   }
-  // TODO: add a button to refresh the entries
+  // TODO: add a button to refresh the entries https://github.com/Gelio/CAL-web/issues/50
   if (isNone(rootObjectIdResOpt)) {
     return <div>Loading</div>;
   }

--- a/frontend/src/views/edit-project/Workbench/Toolbox/Toolbox.tsx
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/Toolbox.tsx
@@ -1,0 +1,121 @@
+import * as TE from "fp-ts/lib/TaskEither";
+import { pipe } from "fp-ts/lib/function";
+import { useEffect, useState } from "react";
+import { ToolboxEntry } from "./interop";
+import { UseToolboxEntryButton } from "./UseToolboxEntryButton";
+
+interface ToolboxProps {
+  editingContextId: string;
+}
+
+const toolboxUrl = `${process.env.REACT_APP_BALTICLSC_API_URL}/backend/dev/toolbox/`;
+
+interface BalticLSCToolboxResponseBody {
+  data: ToolboxEntry[];
+  message: string;
+  success: boolean;
+}
+
+const fetchToolboxEntries = ({
+  authToken,
+  abortSignal,
+}: {
+  authToken: string;
+  abortSignal: AbortSignal;
+}): TE.TaskEither<Error, ToolboxEntry[]> => {
+  return pipe(
+    TE.tryCatch(
+      () =>
+        fetch(toolboxUrl, {
+          headers: { Authorization: `Bearer ${authToken}` },
+          signal: abortSignal,
+        }),
+      (reason) => reason as Error
+    ),
+    TE.chain((response) => {
+      if (!response.ok) {
+        if (response.status === 401) {
+          return TE.left(new Error("Invalid authentication token"));
+        } else {
+          return TE.left(
+            new Error(`Unexpected error (status code ${response.status})`)
+          );
+        }
+      }
+
+      return TE.tryCatch(
+        () => response.json(),
+        (reason) => {
+          console.error("Cannot parse toolbox response", reason);
+          return new Error("Cannot parse response");
+        }
+      );
+    }),
+    TE.chain((body: BalticLSCToolboxResponseBody) => {
+      if (body.success) {
+        return TE.of(body.data);
+      }
+
+      return TE.left(new Error(`Cannot get toolbox entries: ${body.message}`));
+    })
+  );
+};
+
+const useBalticLSCToolboxEntries = ({ authToken }: { authToken: string }) => {
+  const [error, setError] = useState<Error | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [toolboxEntries, setToolboxEntries] = useState<
+    ToolboxEntry[] | undefined
+  >();
+
+  useEffect(() => {
+    setLoading(true);
+    const abortController = new AbortController();
+    const runFetch = pipe(
+      fetchToolboxEntries({ authToken, abortSignal: abortController.signal }),
+      TE.apFirst(TE.fromIO(() => setLoading(false))),
+      TE.match(setError, (entries) => {
+        setToolboxEntries(entries);
+        setError(undefined);
+      })
+    );
+    runFetch();
+
+    return () => abortController.abort();
+  }, [authToken]);
+
+  return { error, loading, toolboxEntries };
+};
+
+export const Toolbox = ({ editingContextId }: ToolboxProps) => {
+  // TODO: allow passing in the auth token, https://github.com/Gelio/CAL-web/issues/43
+  const authToken =
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1bmlxdWVfbmFtZSI6ImRlbW8iLCJzdWIiOiJkZW1vIiwianRpIjoiMjU2Y2RkZjRiZmQ0NGE5YzhmNTg1MGIxY2E0Zjc2YjciLCJzaWQiOiI3OGU5OTA1YzQ2NTU0OTkwODYwYzQxODQ3YmY1OGIxZiIsImV4cCI6MTYzNjkwNDQ2OCwiaXNzIjoid3V0LmJhbHRpY2xzYy5ldSIsImF1ZCI6Ind1dC5iYWx0aWNsc2MuZXUifQ.Mft3pbnrBqQRwXryFmyTNlNB4a9Y_ZHThe9T4IVI70A";
+
+  const { error, loading, toolboxEntries } = useBalticLSCToolboxEntries({
+    authToken,
+  });
+
+  if (loading) {
+    return <div>Loading</div>;
+  }
+
+  if (error) {
+    return <div>Cannot load toolbox: {error.message}</div>;
+  }
+  // TODO: add a button to refresh the entries
+
+  return (
+    <div>
+      {toolboxEntries?.map((entry) => (
+        <UseToolboxEntryButton
+          toolboxEntry={entry}
+          key={entry.uid}
+          editingContextId={editingContextId}
+          // TODO: retrieve root object ID automatically
+          rootObjectId="9e778a79-c5bb-484d-9867-86d4caddec18"
+        />
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/views/edit-project/Workbench/Toolbox/Toolbox.tsx
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/Toolbox.tsx
@@ -6,6 +6,7 @@ import { UseToolboxEntryButton } from "./UseToolboxEntryButton";
 import { useRootObjectId } from "./root-object-id";
 import { isNone } from "fp-ts/lib/Option";
 import { isLeft } from "fp-ts/lib/Either";
+import { makeStyles } from "@material-ui/core";
 
 interface ToolboxProps {
   editingContextId: string;
@@ -90,6 +91,12 @@ const useBalticLSCToolboxEntries = (authToken: string) => {
   return { error, loading, toolboxEntries };
 };
 
+const useStyles = makeStyles((theme) => ({
+  toolbox: {
+    margin: theme.spacing(2, 1),
+  },
+}));
+
 export const Toolbox = ({ editingContextId }: ToolboxProps) => {
   // TODO: allow passing in the auth token, https://github.com/Gelio/CAL-web/issues/43
   const authToken =
@@ -98,6 +105,7 @@ export const Toolbox = ({ editingContextId }: ToolboxProps) => {
   const { error, loading, toolboxEntries } =
     useBalticLSCToolboxEntries(authToken);
   const rootObjectIdResOpt = useRootObjectId(editingContextId);
+  const styles = useStyles();
 
   if (loading) {
     return <div>Loading</div>;
@@ -119,7 +127,7 @@ export const Toolbox = ({ editingContextId }: ToolboxProps) => {
   }
 
   return (
-    <div>
+    <div className={styles.toolbox}>
       {toolboxEntries?.map((entry) => (
         <UseToolboxEntryButton
           toolboxEntry={entry}

--- a/frontend/src/views/edit-project/Workbench/Toolbox/UseToolboxEntryButton.tsx
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/UseToolboxEntryButton.tsx
@@ -66,6 +66,7 @@ export const UseToolboxEntryButton = ({
       E.match(
         (errors) => {
           console.error("Cannot parse toolbox entry", errors);
+          // TODO : show a snackbar notification https://github.com/Gelio/CAL-web/issues/51
         },
         (unitRelease) => {
           const input: GQLCreateUnitCallInput = {

--- a/frontend/src/views/edit-project/Workbench/Toolbox/UseToolboxEntryButton.tsx
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/UseToolboxEntryButton.tsx
@@ -1,0 +1,74 @@
+import * as E from "fp-ts/lib/Either";
+import { v4 as uuid } from "uuid";
+import { gql, useMutation } from "@apollo/client";
+import { getGQLComputationUnitReleaseInput, ToolboxEntry } from "./interop";
+import { pipe } from "fp-ts/lib/function";
+import { GQLCreateUnitCallInput } from "./types";
+import { Button } from "@material-ui/core";
+
+interface UseToolboxEntryButtonProps {
+  toolboxEntry: ToolboxEntry;
+  editingContextId: string;
+  rootObjectId: string;
+}
+
+const createUnitCallMutation = gql`
+  mutation createUnitCall($input: CreateUnitCallInput!) {
+    createUnitCall(input: $input) {
+      __typename
+      ... on CreateUnitCallSuccessPayload {
+        id
+        createdUnitCall {
+          id
+          kind
+          label
+        }
+      }
+      ... on ErrorPayload {
+        message
+      }
+    }
+  }
+`;
+
+export const UseToolboxEntryButton = ({
+  toolboxEntry,
+  rootObjectId,
+  editingContextId,
+}: UseToolboxEntryButtonProps) => {
+  const [createToolboxEntry /* { data, loading, error } */] = useMutation(
+    createUnitCallMutation
+  );
+
+  // TODO: display loading and error information
+  // TODO: use images for button labels
+  // TODO: add tooltips with unit name and version
+
+  return (
+    <Button
+      onClick={() => {
+        pipe(
+          getGQLComputationUnitReleaseInput(toolboxEntry),
+          E.match(
+            (errors) => {
+              console.error("Cannot parse toolbox entry", errors);
+            },
+            (unitRelease) => {
+              const input: GQLCreateUnitCallInput = {
+                id: uuid(),
+                rootObjectId,
+                editingContextId,
+                unitRelease,
+              };
+              createToolboxEntry({
+                variables: { input },
+              });
+            }
+          )
+        );
+      }}
+    >
+      {toolboxEntry.unit.name} {toolboxEntry.version}
+    </Button>
+  );
+};

--- a/frontend/src/views/edit-project/Workbench/Toolbox/index.ts
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/index.ts
@@ -1,0 +1,1 @@
+export * from "./Toolbox";

--- a/frontend/src/views/edit-project/Workbench/Toolbox/interop/computation-unit-release.ts
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/interop/computation-unit-release.ts
@@ -1,0 +1,111 @@
+import * as E from "fp-ts/lib/Either";
+import * as A from "fp-ts/lib/Array";
+import { v4 as uuid } from "uuid";
+
+import type {
+  GQLComputationUnitReleaseInput,
+  GQLDeclaredDataPinInput,
+  ToolboxEntry,
+  ToolboxEntryPin,
+} from "./types";
+import { pipe } from "fp-ts/lib/function";
+import {
+  balticLSCDataBindingToGQL,
+  balticLSCMultiplicityToGQL,
+  GQLDataBinding,
+  GQLMultiplicity,
+} from "./enums";
+
+interface DeclaredDataPinParsingError {
+  pinName: string;
+  errors: Error[];
+}
+const DeclaredDataPinParsingErrorValidation = E.getApplicativeValidation(
+  A.getSemigroup<DeclaredDataPinParsingError>()
+);
+
+export const getGQLComputationUnitReleaseInput = (
+  toolboxEntry: ToolboxEntry
+): E.Either<DeclaredDataPinParsingError[], GQLComputationUnitReleaseInput> => {
+  const pinsResult = pipe(
+    toolboxEntry.pins,
+    A.map((toolboxEntryPin) =>
+      pipe(
+        getGQLDeclaredDataPinInput(toolboxEntryPin),
+        E.mapLeft((errors): DeclaredDataPinParsingError[] =>
+          A.of({
+            pinName: toolboxEntryPin.name,
+            errors,
+          })
+        )
+      )
+    ),
+    A.sequence(DeclaredDataPinParsingErrorValidation)
+  );
+
+  return pipe(
+    pinsResult,
+    E.map(
+      (pins): GQLComputationUnitReleaseInput => ({
+        id: uuid(),
+        name: toolboxEntry.unit.name,
+        version: toolboxEntry.version,
+        pins,
+      })
+    )
+  );
+};
+
+const ErrorValidation = E.getApplicativeValidation(A.getSemigroup<Error>());
+
+const getUnexpectedValueError = (value: unknown, propertyName: string) => () =>
+  [new Error(`Unexpected value ${value} for '${propertyName}'`)];
+
+const getGQLDeclaredDataPinInput = (
+  toolboxEntryPin: ToolboxEntryPin
+): E.Either<Error[], GQLDeclaredDataPinInput> => {
+  const tokenMultiplicityResult = pipe(
+    balticLSCMultiplicityToGQL(toolboxEntryPin.tokenMultiplicity),
+    E.fromOption(
+      getUnexpectedValueError(
+        toolboxEntryPin.tokenMultiplicity,
+        "tokenMultiplicity"
+      )
+    )
+  );
+  const dataMultiplicityResult = pipe(
+    balticLSCMultiplicityToGQL(toolboxEntryPin.dataMultiplicity),
+    E.fromOption(
+      getUnexpectedValueError(
+        toolboxEntryPin.dataMultiplicity,
+        "dataMultiplicity"
+      )
+    )
+  );
+  const dataBindingResult = pipe(
+    balticLSCDataBindingToGQL(toolboxEntryPin.binding),
+    E.fromOption(getUnexpectedValueError(toolboxEntryPin.binding, "binding"))
+  );
+  return pipe(
+    A.sequence(ErrorValidation)([
+      tokenMultiplicityResult,
+      dataMultiplicityResult,
+      dataBindingResult,
+    ]),
+    E.map(
+      ([
+        tokenMultiplicity,
+        dataMultiplicity,
+        dataBinding,
+      ]): GQLDeclaredDataPinInput => {
+        return {
+          id: uuid(),
+          name: toolboxEntryPin.name,
+          dataMultiplicity: dataMultiplicity as GQLMultiplicity,
+          tokenMultiplicity: tokenMultiplicity as GQLMultiplicity,
+          binding: dataBinding as GQLDataBinding,
+        };
+      }
+    )
+  );
+};

--- a/frontend/src/views/edit-project/Workbench/Toolbox/interop/enums.ts
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/interop/enums.ts
@@ -1,0 +1,24 @@
+import * as O from "fp-ts/lib/Option";
+
+export type GQLDataBinding = "REQUIRED" | "PROVIDED";
+export type GQLMultiplicity = "SINGLE" | "MULTIPLE";
+
+const balticLSCDataBindingToGQLMap: Record<number, GQLDataBinding> = {
+  0: "REQUIRED",
+  1: "REQUIRED",
+  2: "PROVIDED",
+  3: "PROVIDED",
+};
+export const balticLSCDataBindingToGQL = (
+  dataBinding: number
+): O.Option<GQLDataBinding> =>
+  O.fromNullable(balticLSCDataBindingToGQLMap[dataBinding]);
+
+const balticLSCMultiplicityToGQLMap: Record<number, GQLMultiplicity> = {
+  0: "SINGLE",
+  1: "MULTIPLE",
+};
+export const balticLSCMultiplicityToGQL = (
+  multiplicity: number
+): O.Option<GQLMultiplicity> =>
+  O.fromNullable(balticLSCMultiplicityToGQLMap[multiplicity]);

--- a/frontend/src/views/edit-project/Workbench/Toolbox/interop/index.ts
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/interop/index.ts
@@ -1,0 +1,2 @@
+export { getGQLComputationUnitReleaseInput } from "./computation-unit-release";
+export type { ToolboxEntry, GQLComputationUnitReleaseInput } from "./types";

--- a/frontend/src/views/edit-project/Workbench/Toolbox/interop/types.ts
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/interop/types.ts
@@ -1,0 +1,53 @@
+import type { GQLDataBinding, GQLMultiplicity } from "./enums";
+
+/**
+ * Contains only the properties that are used in CAL web.
+ */
+export interface ToolboxEntry {
+  description: string | null;
+  pins: ToolboxEntryPin[];
+
+  /**
+   * May not be a valid UUID.
+   * @example face_detector_rel_001
+   * @example 110f65c2-3fc6-411c-9ded-8c8cf96db52d
+   */
+  uid: string;
+
+  /**
+   * @example 0.11
+   * @example v0.1
+   */
+  version: string;
+  unit: ToolboxEntryUnit;
+}
+
+export interface ToolboxEntryPin {
+  name: string;
+
+  tokenMultiplicity: number;
+  dataMultiplicity: number;
+  binding: number;
+}
+
+export interface ToolboxEntryUnit {
+  icon: string;
+  name: string;
+  shortDescription: string | null;
+  longDescription: string | null;
+}
+
+export interface GQLComputationUnitReleaseInput {
+  id: string;
+  name: string;
+  version: string;
+  pins: GQLDeclaredDataPinInput[];
+}
+
+export interface GQLDeclaredDataPinInput {
+  id: string;
+  name: string;
+  binding: GQLDataBinding;
+  tokenMultiplicity: GQLMultiplicity;
+  dataMultiplicity: GQLMultiplicity;
+}

--- a/frontend/src/views/edit-project/Workbench/Toolbox/root-object-id.ts
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/root-object-id.ts
@@ -1,0 +1,200 @@
+import * as TE from "fp-ts/lib/TaskEither";
+import * as T from "fp-ts/lib/Task";
+import * as O from "fp-ts/lib/Option";
+import * as E from "fp-ts/lib/Either";
+import { v4 as uuid } from "uuid";
+import { ApolloClient, gql, Observable, useApolloClient } from "@apollo/client";
+import { pipe } from "fp-ts/lib/function";
+import { useEffect, useState } from "react";
+
+/**
+ * Based on
+ * https://github.com/eclipse-sirius/sirius-components/blob/master/frontend/src/explorer/getTreeEventSubscription.ts
+ */
+const rootObjectIdTreeEventQuery = gql`
+  subscription rootObjectIdTreeEvent($input: TreeEventInput!) {
+    treeEvent(input: $input) {
+      ... on TreeRefreshedEventPayload {
+        id
+        tree {
+          id
+          label
+          children {
+            id
+            label
+            kind
+            children {
+              id
+              label
+              kind
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+interface GQLTreeEventInput {
+  id: string;
+  editingContextId: string;
+  /** ID of nodes to expand */
+  expanded: string[];
+}
+
+/** Children after discovered only IDs of their parents are in the `expanded` array */
+interface GQLRootObjectIdTreeEventResponse {
+  id: string;
+  tree: {
+    id: string;
+    label: string;
+    children: {
+      id: string;
+      label: string;
+      kind: string;
+
+      children: {
+        id: string;
+        label: string;
+        kind: string;
+      }[];
+    }[];
+  };
+}
+
+const getSingleSubscriptionResponse =
+  <T>(observable: Observable<T>): TE.TaskEither<unknown, T> =>
+  () =>
+    new Promise((resolve) => {
+      const subscription = observable.subscribe(
+        (result) => {
+          subscription.unsubscribe();
+          resolve(E.right(result));
+        },
+        (error) => {
+          subscription.unsubscribe();
+          resolve(E.left(error));
+        }
+      );
+    });
+
+type CancellationPoint = <U>(t: T.Task<U>) => T.Task<U>;
+interface TaskCancellationContext {
+  cancel: () => void;
+  cancellationPoint: CancellationPoint;
+}
+
+/**
+ * Allows marking when tasks should be cancelled and actually cancelling them.
+ *
+ * Cancelling means no further tasks will run beyond the cancellation point.
+ *
+ * Promise chains will be created anyway, but the cancellation point may never resolve,
+ * which will not invoke further promise callbacks.
+ */
+const getTaskCancellationContext = (): TaskCancellationContext => {
+  let canceled = false;
+
+  return {
+    cancel: () => {
+      canceled = true;
+    },
+    cancellationPoint: (t) => (canceled ? T.never : t),
+  };
+};
+
+const getTreeEventSingleSubscriptionResponse = (
+  apolloClient: ApolloClient<unknown>,
+  editingContextId: string,
+  expanded: GQLTreeEventInput["expanded"]
+): TE.TaskEither<Error, GQLRootObjectIdTreeEventResponse> =>
+  pipe(
+    getSingleSubscriptionResponse(
+      apolloClient.subscribe<
+        { treeEvent: GQLRootObjectIdTreeEventResponse },
+        { input: GQLTreeEventInput }
+      >({
+        query: rootObjectIdTreeEventQuery,
+        variables: {
+          input: {
+            id: uuid(),
+            editingContextId,
+            expanded,
+          },
+        },
+      })
+    ),
+    TE.mapLeft((error) => {
+      console.error("Unknown error from root object ID subscription", error);
+      return new Error("Unknown error when fetching root object ID");
+    }),
+    TE.chain((result) => {
+      if (result.errors) {
+        console.error("Could not fetch root object ID", result.errors);
+        return TE.left(
+          new Error("GraphQL errors when fetching root object ID")
+        );
+      }
+
+      return TE.of(result.data.treeEvent);
+    })
+  );
+
+/**
+ * Root object (`ComputationApplicationRelease`) ID can be retrieved
+ * by asking for the expanded first level of the Explorer tree.
+ */
+const getRootObjectId = (
+  apolloClient: ApolloClient<unknown>,
+  editingContextId: string,
+  cancellationPoint: CancellationPoint
+): TE.TaskEither<Error, string> =>
+  pipe(
+    getTreeEventSingleSubscriptionResponse(apolloClient, editingContextId, []),
+    cancellationPoint,
+    TE.chain((response) => {
+      const projectNode = response.tree.children[0];
+
+      return getTreeEventSingleSubscriptionResponse(
+        apolloClient,
+        editingContextId,
+        [projectNode.id]
+      );
+    }),
+    TE.map((response) => response.tree.children[0].children[0].id),
+    cancellationPoint
+  );
+
+export const useRootObjectId = (editingContextId: string) => {
+  const apolloClient = useApolloClient();
+  const [rootObjectId, setRootObjectId] = useState<
+    O.Option<E.Either<Error, string>>
+  >(O.none);
+
+  useEffect(() => {
+    const cancellactionContext = getTaskCancellationContext();
+
+    setRootObjectId(O.none);
+
+    pipe(
+      getRootObjectId(
+        apolloClient,
+        editingContextId,
+        cancellactionContext.cancellationPoint
+      ),
+      TE.match(
+        (error) => {
+          console.error("Could not fetch root object ID", error);
+          setRootObjectId(O.some(E.left(error)));
+        },
+        (id) => {
+          setRootObjectId(O.some(E.right(id)));
+        }
+      )
+    )();
+
+    return () => cancellactionContext.cancel();
+  }, [apolloClient, editingContextId]);
+
+  return rootObjectId;
+};

--- a/frontend/src/views/edit-project/Workbench/Toolbox/types.ts
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/types.ts
@@ -1,0 +1,17 @@
+import type { GQLComputationUnitReleaseInput } from "./interop";
+
+export interface GQLCreateUnitCallInput {
+  id: string;
+  rootObjectId: string;
+  editingContextId: string;
+  unitRelease: GQLComputationUnitReleaseInput;
+}
+
+export interface GQLCreateUnitCallSuccessPayload {
+  id: string;
+  createdUnitCall: {
+    id: string;
+    kind: string;
+    label: string;
+  };
+}

--- a/frontend/src/views/edit-project/Workbench/Workbench.tsx
+++ b/frontend/src/views/edit-project/Workbench/Workbench.tsx
@@ -10,6 +10,7 @@ import { useContext } from "react";
 import { LeftSite } from "./LeftSite";
 import { HORIZONTAL, Panels, SECOND_PANEL } from "./Panels";
 import { RightSite } from "./RightSite";
+import { Toolbox } from "./Toolbox";
 import {
   UpdateSelectionEvent,
   WorkbenchContext,
@@ -31,7 +32,7 @@ const useWorkbenchStyles = makeStyles(() => ({
   representationArea: {
     display: "grid",
     gridTemplateColumns: "1fr",
-    gridTemplateRows: "1ft",
+    gridTemplateRows: "min-content 1fr",
   },
 }));
 
@@ -112,6 +113,7 @@ export const Workbench = ({
         className={classes.representationArea}
         data-testid="representation-area"
       >
+        <Toolbox editingContextId={editingContextId} />
         <RepresentationComponent {...props} />
       </div>
     );

--- a/frontend/src/views/edit-project/Workbench/Workbench.tsx
+++ b/frontend/src/views/edit-project/Workbench/Workbench.tsx
@@ -1,0 +1,138 @@
+import {
+  Representation,
+  RepresentationComponentProps,
+  RepresentationContext,
+  Selection,
+} from "@eclipse-sirius/sirius-components";
+import { makeStyles } from "@material-ui/core";
+import { useMachine } from "@xstate/react";
+import { useContext } from "react";
+import { LeftSite } from "./LeftSite";
+import { HORIZONTAL, Panels, SECOND_PANEL } from "./Panels";
+import { RightSite } from "./RightSite";
+import {
+  UpdateSelectionEvent,
+  WorkbenchContext,
+  WorkbenchEvent,
+  workbenchMachine,
+} from "./WorkbenchMachine";
+
+interface WorkbenchProps {
+  editingContextId: string;
+  representation?: Representation;
+}
+
+const useWorkbenchStyles = makeStyles(() => ({
+  main: {
+    display: "grid",
+    gridTemplateRows: "minmax(0, 1fr)",
+    gridTemplateColumns: "1fr",
+  },
+  representationArea: {
+    display: "grid",
+    gridTemplateColumns: "1fr",
+    gridTemplateRows: "1ft",
+  },
+}));
+
+/**
+ * Altered sirius-components `Workbench`.
+ *
+ * The Workbench component does not allow customizing the displayed components
+ * https://github.com/eclipse-sirius/sirius-components/issues/693
+ * To be able to add new components, we need to have our own Workbench component.
+ *
+ * It is very similar to the original one.
+ * @see https://github.com/eclipse-sirius/sirius-components/blob/master/frontend/src/workbench/Workbench.tsx
+ *
+ * See https://github.com/Gelio/CAL-web/issues/18#issuecomment-967889436 for more context on the customization.
+ */
+export const Workbench = ({
+  editingContextId,
+  representation,
+}: WorkbenchProps) => {
+  const classes = useWorkbenchStyles();
+  const { registry } = useContext(RepresentationContext);
+  const [{ context }, dispatch] = useMachine<WorkbenchContext, WorkbenchEvent>(
+    workbenchMachine,
+    {
+      context: {
+        displayedRepresentation: representation,
+      },
+    }
+  );
+  const { selection, displayedRepresentation } = context;
+
+  const setSelection = (selection: Selection) => {
+    const isRepresentation = registry.isRepresentation(selection.kind);
+    const updateSelectionEvent: UpdateSelectionEvent = {
+      type: "UPDATE_SELECTION",
+      selection,
+      isRepresentation,
+    };
+    dispatch(updateSelectionEvent);
+  };
+
+  const leftSite = (
+    <LeftSite
+      editingContextId={editingContextId}
+      selection={selection}
+      setSelection={setSelection}
+      // TODO: change to `true` after testing that everything works
+      readOnly={false}
+    />
+  );
+
+  const rightSite = (
+    <RightSite
+      editingContextId={editingContextId}
+      selection={selection}
+      setSelection={setSelection}
+      readOnly={false}
+    />
+  );
+
+  // NOTE: the original Workbench uses `OnboardArea` here, but that component is not exposed
+  // @see https://github.com/eclipse-sirius/sirius-components/blob/ab8097c6c3593f10fdd16f9212762624a3639ccc/frontend/src/workbench/Workbench.tsx#L103-L110
+  // @see https://github.com/eclipse-sirius/sirius-components/issues/830#issuecomment-967976773
+  let main = <div>No representation found.</div>;
+  if (displayedRepresentation) {
+    const RepresentationComponent = registry.getComponent(
+      displayedRepresentation
+    );
+    const props: RepresentationComponentProps = {
+      editingContextId,
+      representationId: displayedRepresentation.id,
+      selection,
+      setSelection,
+      readOnly: false,
+    };
+    main = (
+      <div
+        className={classes.representationArea}
+        data-testid="representation-area"
+      >
+        <RepresentationComponent {...props} />
+      </div>
+    );
+  }
+
+  return (
+    <Panels
+      orientation={HORIZONTAL}
+      firstPanel={leftSite}
+      secondPanel={
+        <div className={classes.main} data-testid="representationAndProperties">
+          <Panels
+            orientation={HORIZONTAL}
+            resizablePanel={SECOND_PANEL}
+            firstPanel={main}
+            secondPanel={rightSite}
+            initialResizablePanelSize={300}
+          />
+        </div>
+      }
+      initialResizablePanelSize={300}
+    />
+  );
+};

--- a/frontend/src/views/edit-project/Workbench/WorkbenchMachine.ts
+++ b/frontend/src/views/edit-project/Workbench/WorkbenchMachine.ts
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { Representation, Selection } from "@eclipse-sirius/sirius-components";
+import { assign, Machine } from "xstate";
+
+export interface WorkbenchStateSchema {
+  states: { initial: {} };
+}
+
+export type SchemaValue = "initial";
+
+export interface WorkbenchContext {
+  selection: Selection | null;
+  representations: Representation[];
+  displayedRepresentation: Representation | null;
+}
+
+export type ShowRepresentationEvent = {
+  type: "SHOW_REPRESENTATION";
+  representation: Representation;
+};
+export type HideRepresentationEvent = {
+  type: "HIDE_REPRESENTATION";
+  representation: Representation;
+};
+export type UpdateSelectionEvent = {
+  type: "UPDATE_SELECTION";
+  selection: Selection;
+  isRepresentation: boolean;
+};
+export type WorkbenchEvent =
+  | UpdateSelectionEvent
+  | ShowRepresentationEvent
+  | HideRepresentationEvent;
+
+export const workbenchMachine = Machine<
+  WorkbenchContext,
+  WorkbenchStateSchema,
+  WorkbenchEvent
+>(
+  {
+    initial: "initial",
+    context: {
+      selection: null,
+      representations: [],
+      displayedRepresentation: null,
+    },
+    states: {
+      initial: {
+        on: {
+          UPDATE_SELECTION: {
+            target: "initial",
+            actions: "updateSelection",
+          },
+          SHOW_REPRESENTATION: {
+            target: "initial",
+            actions: "showRepresentation",
+          },
+          HIDE_REPRESENTATION: {
+            target: "initial",
+            actions: "hideRepresentation",
+          },
+        },
+      },
+    },
+  },
+  {
+    actions: {
+      updateSelection: assign((context, event) => {
+        const { selection, isRepresentation } = event as UpdateSelectionEvent;
+
+        if (isRepresentation) {
+          const { id, label, kind } = selection;
+          const representation: Representation = { id, label, kind };
+
+          let newRepresentations = [...context.representations];
+          const selectedRepresentation = newRepresentations.find(
+            (representation) => selection.id === representation.id
+          );
+          if (!selectedRepresentation) {
+            newRepresentations = [...newRepresentations, representation];
+          }
+
+          return {
+            selection,
+            displayedRepresentation: representation,
+            representations: newRepresentations,
+          };
+        }
+
+        return { selection };
+      }),
+      showRepresentation: assign((_, event) => {
+        const { representation } = event as ShowRepresentationEvent;
+        return { displayedRepresentation: representation };
+      }),
+      hideRepresentation: assign((context, event) => {
+        const { representation: representationToHide } =
+          event as HideRepresentationEvent;
+
+        const previousIndex = context.representations.findIndex(
+          (representation) =>
+            representation.id === context.displayedRepresentation.id
+        );
+        const newRepresentations = context.representations.filter(
+          (representation) => representation.id !== representationToHide.id
+        );
+
+        if (newRepresentations.length === 0) {
+          // There are no representations anymore
+          return { displayedRepresentation: null, representations: [] };
+        } else {
+          const newIndex = newRepresentations.findIndex(
+            (representation) =>
+              representation.id === context.displayedRepresentation.id
+          );
+
+          if (newIndex !== -1) {
+            // The previously displayed representation has not been closed
+            return { representations: newRepresentations };
+          } else if (newRepresentations.length === previousIndex) {
+            // The previous representation has been closed and it was the last one
+            const displayedRepresentation =
+              newRepresentations[previousIndex - 1];
+            return {
+              displayedRepresentation,
+              representations: newRepresentations,
+            };
+          } else {
+            const displayedRepresentation = newRepresentations[previousIndex];
+            return {
+              displayedRepresentation,
+              representations: newRepresentations,
+            };
+          }
+        }
+      }),
+    },
+  }
+);

--- a/frontend/src/views/edit-project/Workbench/index.ts
+++ b/frontend/src/views/edit-project/Workbench/index.ts
@@ -1,0 +1,1 @@
+export * from "./Workbench";

--- a/frontend/src/views/edit-project/Workbench/validation/ValidationWebSocketContainer.tsx
+++ b/frontend/src/views/edit-project/Workbench/validation/ValidationWebSocketContainer.tsx
@@ -1,0 +1,204 @@
+/**
+ * Copied from
+ * @see https://github.com/eclipse-sirius/sirius-components/blob/master/frontend/src/validation/ValidationWebSocketContainer.tsx
+ *
+ * The component is used to recreate `Workbench` from `sirius-components`.
+ * `ValidationWebSocketContainer` is not exported as public API.
+ * @see https://github.com/eclipse-sirius/sirius-components/issues/830#issuecomment-967976773
+ */
+
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+import { useSubscription } from "@apollo/client";
+import Accordion from "@material-ui/core/Accordion";
+import AccordionDetails from "@material-ui/core/AccordionDetails";
+import AccordionSummary from "@material-ui/core/AccordionSummary";
+import Divider from "@material-ui/core/Divider";
+import IconButton from "@material-ui/core/IconButton";
+import Snackbar from "@material-ui/core/Snackbar";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+import Typography from "@material-ui/core/Typography";
+import CloseIcon from "@material-ui/icons/Close";
+import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import { useMachine } from "@xstate/react";
+import gql from "graphql-tag";
+import React, { useEffect } from "react";
+import {
+  GQLValidationEventSubscription,
+  ValidationWebSocketContainerProps,
+} from "./ValidationWebSocketContainer.types";
+import {
+  HandleCompleteEvent,
+  HandleSubscriptionResultEvent,
+  HideToastEvent,
+  SchemaValue,
+  ShowToastEvent,
+  ValidationWebSocketContainerContext,
+  ValidationWebSocketContainerEvent,
+  validationWebSocketContainerMachine,
+} from "./ValidationWebSocketContainerMachine";
+
+const validationEventSubscription = gql`
+  subscription validationEvent($input: ValidationEventInput!) {
+    validationEvent(input: $input) {
+      __typename
+      ... on ValidationRefreshedEventPayload {
+        id
+        validation {
+          id
+          label
+          diagnostics {
+            id
+            kind
+            message
+          }
+        }
+      }
+    }
+  }
+`;
+
+const useValidationWebSocketContainerStyle = makeStyles((theme) => ({
+  root: {
+    padding: "8px",
+  },
+  heading: {
+    flexBasis: "33.33%",
+    flexShrink: 0,
+  },
+  secondaryHeading: {
+    color: theme.palette.text.secondary,
+  },
+  accordionDetailsRoot: {
+    flexDirection: "column",
+  },
+  divider: {
+    margin: "8px 0",
+  },
+  idle: {
+    padding: theme.spacing(1),
+  },
+}));
+
+export const ValidationWebSocketContainer = ({
+  editingContextId,
+}: ValidationWebSocketContainerProps) => {
+  const classes = useValidationWebSocketContainerStyle();
+  const [{ value, context }, dispatch] = useMachine<
+    ValidationWebSocketContainerContext,
+    ValidationWebSocketContainerEvent
+  >(validationWebSocketContainerMachine);
+  const { toast, validationWebSocketContainer } = value as SchemaValue;
+  const { id, validation, message } = context;
+
+  const { error } = useSubscription<GQLValidationEventSubscription>(
+    validationEventSubscription,
+    {
+      variables: {
+        input: {
+          id,
+          editingContextId,
+        },
+      },
+      fetchPolicy: "no-cache",
+      onSubscriptionData: ({ subscriptionData }) => {
+        const handleDataEvent: HandleSubscriptionResultEvent = {
+          type: "HANDLE_SUBSCRIPTION_RESULT",
+          result: subscriptionData,
+        };
+        dispatch(handleDataEvent);
+      },
+      onSubscriptionComplete: () => {
+        const completeEvent: HandleCompleteEvent = { type: "HANDLE_COMPLETE" };
+        dispatch(completeEvent);
+      },
+    }
+  );
+
+  useEffect(() => {
+    if (error) {
+      const { message } = error;
+      const showToastEvent: ShowToastEvent = { type: "SHOW_TOAST", message };
+      dispatch(showToastEvent);
+    }
+  }, [error, dispatch]);
+
+  let content = null;
+
+  if (validationWebSocketContainer === "ready") {
+    const accordions = validation.categories.map((category) => {
+      const details = category.diagnostics
+        .map<React.ReactNode>((diagnostic) => {
+          return (
+            <Typography key={diagnostic.id}>{diagnostic.message}</Typography>
+          );
+        })
+        .reduce((prev, current, index) => [
+          prev,
+          <Divider key={`Divider-${index}`} className={classes.divider} />,
+          current,
+        ]);
+
+      return (
+        <Accordion key={category.kind}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography className={classes.heading}>{category.kind}</Typography>
+            <Typography className={classes.secondaryHeading}>
+              {category.diagnostics.length} diagnostics
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails className={classes.accordionDetailsRoot}>
+            {details}
+          </AccordionDetails>
+        </Accordion>
+      );
+    });
+
+    if (accordions.length > 0) {
+      content = <div className={classes.root}>{accordions}</div>;
+    } else {
+      content = (
+        <div className={classes.idle}>
+          <Typography variant="subtitle2">No diagnostic available</Typography>
+        </div>
+      );
+    }
+  }
+
+  return (
+    <>
+      {content}
+      <Snackbar
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "right",
+        }}
+        open={toast === "visible"}
+        autoHideDuration={3000}
+        onClose={() => dispatch({ type: "HIDE_TOAST" } as HideToastEvent)}
+        message={message}
+        action={
+          <IconButton
+            size="small"
+            aria-label="close"
+            color="inherit"
+            onClick={() => dispatch({ type: "HIDE_TOAST" } as HideToastEvent)}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        }
+        data-testid="error"
+      />
+    </>
+  );
+};

--- a/frontend/src/views/edit-project/Workbench/validation/ValidationWebSocketContainer.types.ts
+++ b/frontend/src/views/edit-project/Workbench/validation/ValidationWebSocketContainer.types.ts
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+export interface ValidationWebSocketContainerProps {
+  editingContextId: string;
+}
+
+export interface GQLValidationEventSubscription {
+  validationEvent: GQLValidationEventPayload;
+}
+
+export interface GQLValidationEventPayload {
+  __typename: string;
+}
+
+export interface GQLValidationRefreshedEventPayload
+  extends GQLValidationEventPayload {
+  id: string;
+  validation: GQLValidation;
+}
+
+export interface GQLValidation {
+  id: string;
+  label: string;
+  diagnostics: GQLDiagnostic[];
+}
+
+export interface GQLDiagnostic {
+  id: string;
+  kind: string;
+  message: string;
+}
+
+export interface Validation {
+  categories: Category[];
+}
+export interface Category {
+  kind: string;
+  diagnostics: Diagnostic[];
+}
+
+export interface Diagnostic {
+  id: string;
+  message: string;
+}

--- a/frontend/src/views/edit-project/Workbench/validation/ValidationWebSocketContainerMachine.ts
+++ b/frontend/src/views/edit-project/Workbench/validation/ValidationWebSocketContainerMachine.ts
@@ -1,0 +1,191 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Obeo and others.
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Obeo - initial API and implementation
+ *******************************************************************************/
+
+import { SubscriptionResult } from "@apollo/client";
+import { v4 as uuid } from "uuid";
+import { assign, Machine } from "xstate";
+import {
+  Category,
+  GQLValidationEventPayload,
+  GQLValidationEventSubscription,
+  GQLValidationRefreshedEventPayload,
+  Validation,
+} from "./ValidationWebSocketContainer.types";
+
+export interface ValidationWebSocketContainerStateSchema {
+  states: {
+    toast: {
+      states: {
+        visible: {};
+        hidden: {};
+      };
+    };
+    validationWebSocketContainer: {
+      states: {
+        idle: {};
+        ready: {};
+        complete: {};
+      };
+    };
+  };
+}
+
+export type SchemaValue = {
+  toast: "visible" | "hidden";
+  validationWebSocketContainer: "idle" | "ready" | "complete";
+};
+
+export interface ValidationWebSocketContainerContext {
+  id: string;
+  validation: Validation | null;
+  message: string | null;
+}
+
+export type ShowToastEvent = { type: "SHOW_TOAST"; message: string };
+export type HideToastEvent = { type: "HIDE_TOAST" };
+export type HandleSubscriptionResultEvent = {
+  type: "HANDLE_SUBSCRIPTION_RESULT";
+  result: SubscriptionResult<GQLValidationEventSubscription>;
+};
+export type HandleCompleteEvent = { type: "HANDLE_COMPLETE" };
+export type ValidationWebSocketContainerEvent =
+  | HandleSubscriptionResultEvent
+  | HandleCompleteEvent
+  | ShowToastEvent
+  | HideToastEvent;
+
+const isValidationRefreshedEventPayload = (
+  payload: GQLValidationEventPayload
+): payload is GQLValidationRefreshedEventPayload =>
+  payload.__typename === "ValidationRefreshedEventPayload";
+
+export const validationWebSocketContainerMachine = Machine<
+  ValidationWebSocketContainerContext,
+  ValidationWebSocketContainerStateSchema,
+  ValidationWebSocketContainerEvent
+>(
+  {
+    type: "parallel",
+    context: {
+      id: uuid(),
+      validation: null,
+      message: null,
+    },
+    states: {
+      toast: {
+        initial: "hidden",
+        states: {
+          hidden: {
+            on: {
+              SHOW_TOAST: {
+                target: "visible",
+                actions: "setMessage",
+              },
+            },
+          },
+          visible: {
+            on: {
+              HIDE_TOAST: {
+                target: "hidden",
+                actions: "clearMessage",
+              },
+            },
+          },
+        },
+      },
+      validationWebSocketContainer: {
+        initial: "idle",
+        states: {
+          idle: {
+            on: {
+              HANDLE_SUBSCRIPTION_RESULT: [
+                {
+                  cond: "isValidationRefreshedEventPayload",
+                  target: "ready",
+                  actions: "handleSubscriptionResult",
+                },
+                {
+                  target: "idle",
+                  actions: "handleSubscriptionResult",
+                },
+              ],
+            },
+          },
+          ready: {
+            on: {
+              HANDLE_SUBSCRIPTION_RESULT: {
+                target: "ready",
+                actions: "handleSubscriptionResult",
+              },
+              HANDLE_COMPLETE: {
+                target: "complete",
+              },
+            },
+          },
+          complete: {
+            type: "final",
+          },
+        },
+      },
+    },
+  },
+  {
+    guards: {
+      isValidationRefreshedEventPayload: (_, event) => {
+        const { result } = event as HandleSubscriptionResultEvent;
+        const { data } = result;
+        return isValidationRefreshedEventPayload(data.validationEvent);
+      },
+    },
+    actions: {
+      handleSubscriptionResult: assign((_, event) => {
+        const { result } = event as HandleSubscriptionResultEvent;
+        const { data } = result;
+        if (isValidationRefreshedEventPayload(data.validationEvent)) {
+          const { validation } = data.validationEvent;
+
+          const categories: Category[] = [];
+          const processedValidation: Validation = { categories };
+
+          validation.diagnostics.forEach((diagnostic) => {
+            let category: Category = categories.find(
+              (category) => category.kind === diagnostic.kind
+            );
+            if (!category) {
+              category = {
+                kind: diagnostic.kind,
+                diagnostics: [],
+              };
+              categories.push(category);
+            }
+
+            category.diagnostics.push({
+              id: diagnostic.id,
+              message: diagnostic.message,
+            });
+          });
+
+          return { validation: processedValidation };
+        }
+        return {};
+      }),
+      setMessage: assign((_, event) => {
+        const { message } = event as ShowToastEvent;
+        return { message };
+      }),
+      clearMessage: assign((_) => {
+        return { message: null };
+      }),
+    },
+  }
+);

--- a/frontend/src/views/edit-project/Workbench/validation/index.ts
+++ b/frontend/src/views/edit-project/Workbench/validation/index.ts
@@ -1,0 +1,1 @@
+export * from "./ValidationWebSocketContainer";


### PR DESCRIPTION
Add a toolbox above the diagram editor showing buttons that correspond to entries in the BalticLSC toolbox. Clicking a button results in creating a `UnitCall` for a given toolbox unit release. A `ComputationUnitRelease` may get also created in the process if it is the first time a `UnitCall` for that `ComputationUnitRelease` is added to the diagram.

There are also tooltips for each toolbox entry that show the name and the version of that entry.

Some components in this PR come from https://github.com/eclipse-sirius/sirius-components/tree/master/frontend. This way I can modify the structure of the displayed workbench UI. Copied components have Eclipse license headers.

Closes #18 

## Problems and solutions

1. It was not possible to inject components into the `Workbench` component from Sirius Components. I had to copy the code into this repository to be able to change it.

    See https://github.com/Gelio/CAL-web/issues/18#issuecomment-967889436 for more context about this problem.

2. The ID of the `ComputationApplicationRelease` is necessary to create a unit call. It is not easy to get it from the UI. I had to use 2 sequential `treeEvent` subscriptions to get it. Hacky, but it works.

    See https://github.com/Gelio/CAL-web/issues/18#issuecomment-967970808 for more context about this problem.

## Media

![image](https://user-images.githubusercontent.com/889383/141693517-3915098d-4689-4425-8abf-e1a26b264f27.png)

https://user-images.githubusercontent.com/889383/141693337-b2fdee89-4e99-4ae7-9fce-385283e566de.mp4

