### PR TITLE
CAL semantic model validations and first rule

### DIFF
--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/ISemanticCALValidationRule.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/ISemanticCALValidationRule.java
@@ -1,0 +1,11 @@
+package org.eclipse.sirius.web.services.validation.semantic;
+
+import java.util.List;
+
+import org.eclipse.emf.common.util.Diagnostic;
+
+import eu.balticlsc.model.CAL.ComputationApplicationRelease;
+
+public interface ISemanticCALValidationRule {
+    List<Diagnostic> validate(ComputationApplicationRelease applicationRelease);
+}

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowLoops.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowLoops.java
@@ -1,0 +1,53 @@
+package org.eclipse.sirius.web.services.validation.semantic.rules;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.common.util.BasicDiagnostic;
+import org.eclipse.sirius.web.services.validation.semantic.ISemanticCALValidationRule;
+import org.springframework.stereotype.Service;
+
+import eu.balticlsc.model.CAL.ComputationApplicationRelease;
+import eu.balticlsc.model.CAL.DataFlow;
+import eu.balticlsc.model.CAL.UnitCall;
+import eu.balticlsc.model.CAL.ComputedDataPin;
+
+@Service
+public class NoDataFlowLoops implements ISemanticCALValidationRule {
+
+    @Override
+    public List<Diagnostic> validate(ComputationApplicationRelease applicationRelease) {
+        // @formatter:off
+        return applicationRelease.getFlows()
+            .stream()
+            .map(this::isOnSameUnitCall)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toList());
+        // @formatter:on
+    }
+
+    private Optional<Diagnostic> isOnSameUnitCall(DataFlow flow) {
+        var source = flow.getSource();
+        var target = flow.getTarget();
+        if (source == null || target == null) {
+            return Optional.empty();
+        }
+
+        if (!ComputedDataPin.class.isInstance(source) || !ComputedDataPin.class.isInstance(target)) {
+            return Optional.empty();
+        }
+
+        if (source.eContainer() == target.eContainer()) {
+            var unitCall = (UnitCall) source.eContainer();
+            var message = String.format("Data cannot flow between pins on the same Unit Call '%s'", unitCall.getName()); //$NON-NLS-1$
+            var diagnostic = new BasicDiagnostic(Diagnostic.ERROR, String.valueOf(flow.hashCode()), 1, message, new Object[0]);
+            return Optional.of(diagnostic);
+        }
+
+        return Optional.empty();
+    }
+
+}


### PR DESCRIPTION
Modify the existing validation logic to also run CAL semantic model validations.

A CAL semantic validation rule is a class that implements the following interface:

```java
interface ISemanticCALValidationRule {
    List<Diagnostic> validate(ComputationApplicationRelease applicationRelease);
}
```

This PR also adds one validation rule to serve as an example and verify that the functionality works.

Closes #55
Closes #56


https://user-images.githubusercontent.com/889383/141965436-069791b9-0e54-4277-8111-419c12547f01.mp4

I initially thought I could add a new validation provider instead of modifying the one for the built-in diagnostics. Multiple validation providers are not supported by Sirius Components (see https://github.com/Gelio/CAL-web/issues/55#issuecomment-970086134), so I had to modify the existing one.