### PR TITLE
Add `DataFlowDirection` semantic validation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,4 +223,21 @@ NOTE: Files modified in patches will not run through the pre-commit hook. Thus,
 make sure to wait for the CI to pass before merging the changes to see if the
 project still builds and passes all checks.
 
+## Running tests
+
+To execute tests of the backend application, run the following command in the
+`backend` directory:
+
+```sh
+./mvnw clean verify
+```
+
+This will compile the application and run unit and integration tests.
+
+After modifying the code, make sure to run the tests again using the same
+command. Running only `./mvnw test` or `./mvnw verify` can lead to
+false-positive errors being reported. See
+[this GitHub issue](https://github.com/Gelio/CAL-web/issues/58#issuecomment-971819426)
+for more information.
+
 <!-- vim: set tw=80: -->

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/DataFlowDirection.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/DataFlowDirection.java
@@ -1,0 +1,59 @@
+package org.eclipse.sirius.web.services.validation.semantic.rules;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.common.util.BasicDiagnostic;
+import org.eclipse.sirius.web.services.validation.semantic.ISemanticCALValidationRule;
+import org.springframework.stereotype.Service;
+
+import eu.balticlsc.model.CAL.ComputationApplicationRelease;
+import eu.balticlsc.model.CAL.DataFlow;
+import eu.balticlsc.model.CAL.DataBinding;
+
+@Service
+public class DataFlowDirection implements ISemanticCALValidationRule {
+
+    @Override
+    public List<Diagnostic> validate(ComputationApplicationRelease applicationRelease) {
+        // @formatter:off
+        return applicationRelease.getFlows()
+            .stream()
+            .flatMap(this::hasValidDirection)
+            .collect(Collectors.toList());
+        // @formatter:on
+    }
+
+    private Stream<Diagnostic> hasValidDirection(DataFlow flow) {
+        var sourceDataPin = Optional.ofNullable(flow.getSource()).flatMap(source -> Optional.ofNullable(source.getDataPin()));
+        // @formatter:off
+        var sourceDiagnostic = sourceDataPin.flatMap(source -> source.getBinding() == DataBinding.PROVIDED
+                ? Optional.empty()
+                : Optional.of(new BasicDiagnostic(
+                        Diagnostic.ERROR,
+                        String.valueOf(flow.hashCode()),
+                        1,
+                        String.format("Data flow cannot start from required pin '%s'", source.getName()), //$NON-NLS-1$
+                        new Object[0]
+                    )));
+        // @formatter:on
+
+        var targetDataPin = Optional.ofNullable(flow.getTarget()).flatMap(target -> Optional.ofNullable(target.getDataPin()));
+        // @formatter:off
+        var targetDiagnostic = targetDataPin.flatMap(target -> target.getBinding() == DataBinding.REQUIRED
+                ? Optional.empty()
+                : Optional.of(new BasicDiagnostic(
+                        Diagnostic.ERROR,
+                        String.valueOf(flow.hashCode()),
+                        1,
+                        String.format("Data flow cannot end in provided pin '%s'", target.getName()), //$NON-NLS-1$
+                        new Object[0]
+                    )));
+        // @formatter:on
+
+        return Stream.of(sourceDiagnostic, targetDiagnostic).filter(Optional::isPresent).map(Optional::get);
+    }
+}

--- a/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/validation/semantic/rules/DataFlowDirectionTests.java
+++ b/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/validation/semantic/rules/DataFlowDirectionTests.java
@@ -1,0 +1,71 @@
+package org.eclipse.sirius.web.services.validation.semantic.rules;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import eu.balticlsc.model.CAL.CALFactory;
+import eu.balticlsc.model.CAL.DataBinding;
+
+public class DataFlowDirectionTests {
+    @Test
+    public void testInvalidDirection() {
+        var factory = CALFactory.eINSTANCE;
+        var application = factory.createComputationApplicationRelease();
+        var pins = application.getApplicationDataPins();
+
+        var providedPin = factory.createApplicationDataPin();
+        providedPin.setName("Provided (output)"); //$NON-NLS-1$
+        providedPin.setBinding(DataBinding.PROVIDED);
+        pins.add(providedPin);
+
+        var requiredPin = factory.createApplicationDataPin();
+        requiredPin.setName("Required (input)"); //$NON-NLS-1$
+        requiredPin.setBinding(DataBinding.REQUIRED);
+        pins.add(requiredPin);
+
+        var dataFlow = factory.createDataFlow();
+        dataFlow.setSource(requiredPin);
+        dataFlow.setTarget(providedPin);
+        application.getFlows().add(dataFlow);
+
+        var rule = new DataFlowDirection();
+        var diagnostics = rule.validate(application);
+
+        assertThat(diagnostics).hasSize(2);
+        // @formatter:off
+        assertThat(diagnostics).satisfiesExactlyInAnyOrder(
+                diagnostic -> assertThat(diagnostic.getMessage())
+                    .contains("Data flow cannot start from required pin 'Required (input)'"), //$NON-NLS-1$
+                diagnostic -> assertThat(diagnostic.getMessage())
+                    .contains("Data flow cannot end in provided pin 'Provided (output)'") //$NON-NLS-1$
+        );
+        // @formatter:on
+    }
+
+    @Test
+    public void testValidDirection() {
+        var factory = CALFactory.eINSTANCE;
+        var application = factory.createComputationApplicationRelease();
+        var pins = application.getApplicationDataPins();
+
+        var providedPin = factory.createApplicationDataPin();
+        providedPin.setName("Provided (output)"); //$NON-NLS-1$
+        providedPin.setBinding(DataBinding.PROVIDED);
+        pins.add(providedPin);
+
+        var requiredPin = factory.createApplicationDataPin();
+        requiredPin.setName("Required (input)"); //$NON-NLS-1$
+        requiredPin.setBinding(DataBinding.REQUIRED);
+        pins.add(requiredPin);
+
+        var dataFlow = factory.createDataFlow();
+        dataFlow.setSource(providedPin);
+        dataFlow.setTarget(requiredPin);
+        application.getFlows().add(dataFlow);
+
+        var rule = new DataFlowDirection();
+        var diagnostics = rule.validate(application);
+
+        assertThat(diagnostics).isEmpty();
+    }
+}


### PR DESCRIPTION
The `DataFlowDirection` semantic validation rule ensures that `DataFlow` are from Provided data pins to Required data pins.

There are 2 tests to make sure the rule works correctly.

Closes #27

![image](https://user-images.githubusercontent.com/889383/142266754-1565221d-cfad-4637-9fb3-3e4ffc40ee30.png)

Notice the 2 highlighted diagnostics