### PR TITLE
Implement `NoDataFlowCycles` semantic validation rule

### DIFF
--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCycles.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCycles.java
@@ -1,0 +1,17 @@
+package org.eclipse.sirius.web.services.validation.semantic.rules;
+
+import java.util.List;
+
+import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.sirius.web.services.validation.semantic.ISemanticCALValidationRule;
+import org.springframework.stereotype.Service;
+
+import eu.balticlsc.model.CAL.ComputationApplicationRelease;
+
+@Service
+public class NoDataFlowCycles implements ISemanticCALValidationRule {
+    @Override
+    public List<Diagnostic> validate(ComputationApplicationRelease applicationRelease) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCycles.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCycles.java
@@ -1,17 +1,131 @@
 package org.eclipse.sirius.web.services.validation.semantic.rules;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Stack;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.eclipse.emf.common.util.BasicDiagnostic;
 import org.eclipse.emf.common.util.Diagnostic;
+import org.eclipse.emf.ecore.EObject;
 import org.eclipse.sirius.web.services.validation.semantic.ISemanticCALValidationRule;
 import org.springframework.stereotype.Service;
 
 import eu.balticlsc.model.CAL.ComputationApplicationRelease;
+import eu.balticlsc.model.CAL.ComputedDataPin;
+import eu.balticlsc.model.CAL.ConnectableDataPin;
+import eu.balticlsc.model.CAL.DataBinding;
+import eu.balticlsc.model.CAL.DataFlow;
+import eu.balticlsc.model.CAL.UnitCall;
 
 @Service
 public class NoDataFlowCycles implements ISemanticCALValidationRule {
     @Override
     public List<Diagnostic> validate(ComputationApplicationRelease applicationRelease) {
-        throw new UnsupportedOperationException();
+        // @formatter:off
+        return this.findCycle(applicationRelease)
+            .map(cycle -> new BasicDiagnostic(
+                Diagnostic.ERROR,
+                String.valueOf(cycle.hashCode()),
+                1,
+                String.format("Data flow must not form a cycle. Detected cycle: %s", this.formatCycle(cycle)), //$NON-NLS-1$
+                new Object[0]
+            ))
+            .stream()
+            .collect(Collectors.toList());
+        // @formatter:on
+    }
+
+    private Optional<List<UnitCall>> findCycle(ComputationApplicationRelease applicationRelease) {
+        // OBSERVATION:
+        // ApplicationDataPins can be ignored, because they will not cause cycles.
+        // They can only have a single output or a single input. No cycle can go through them.
+
+        // NOTE: main idea for finding the cycle is similar to topological sorting:
+        // Depth-first search starting from Unit Calls and following their DataPin flows.
+        // Visited UnitCalls whose descendants form a directed acyclic graph are cached
+        // for improved performance - the search does not need to recurse into them.
+
+        /** Unit calls that do not start a cycle */
+        var visitedUnitCalls = new HashSet<UnitCall>();
+        var path = new Stack<UnitCall>();
+
+        for (UnitCall startingUnitCall : applicationRelease.getCalls()) {
+            if (visitedUnitCalls.contains(startingUnitCall)) {
+                continue;
+            }
+
+            var foundCycle = this.visitUnitCall(visitedUnitCalls, path, startingUnitCall);
+            if (foundCycle.isPresent()) {
+                return foundCycle;
+            }
+
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * <p>
+     * Performs a Depth-First Search trying to find a cycle.
+     * </p>
+     *
+     * <p>
+     * Assumes that `unitCall` has not been visited yet.
+     * </p>
+     */
+    private Optional<List<UnitCall>> visitUnitCall(HashSet<UnitCall> visitedUnitCalls, Stack<UnitCall> path, UnitCall unitCall) {
+        path.add(unitCall);
+
+        // @formatter:off
+        var providedPins = unitCall.getPins()
+            .stream()
+            .filter(pin -> Optional.ofNullable(pin.getDataPin())
+                .map(declaredDataPin -> declaredDataPin.getBinding() == DataBinding.PROVIDED)
+                .orElseGet(() -> false)
+            );
+        var outgoingFlows = providedPins.map(pin -> Optional.ofNullable(pin.getOutgoing()));
+        var neighboringUnitCalls = outgoingFlows.map(flow ->
+                flow.map(DataFlow::getTarget)
+                    .filter(ComputedDataPin.class::isInstance)
+                    .map(ConnectableDataPin.class::cast)
+                    .map(EObject::eContainer)
+                    // SAFETY: ConnectableDataPins can only be contained in UnitCalls
+                    .map(UnitCall.class::cast)
+            )
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toList());
+        // @formatter:on
+
+        for (var neighboringUnitCall : neighboringUnitCalls) {
+            // NOTE: the cycle may be only in the final part of the path
+            // Need to find which node starts the cycle and report only
+            // descendants of that node.
+            var indexInPath = path.indexOf(neighboringUnitCall);
+            var neighborFormsCycle = indexInPath > -1;
+            if (neighborFormsCycle) {
+                return Optional.of(path.subList(indexInPath, path.size()));
+            } else {
+                var foundCycle = this.visitUnitCall(visitedUnitCalls, path, neighboringUnitCall);
+                if (foundCycle.isPresent()) {
+                    return foundCycle;
+                }
+            }
+        }
+
+        path.remove(unitCall);
+        return Optional.empty();
+    }
+
+    private String formatCycle(List<UnitCall> cycle) {
+        var delimiter = " -> "; //$NON-NLS-1$
+        // NOTE: makes sure the cycle is closed by repeating the name of the first Unit Call
+        var cycleWithDuplicatedFirstUnitCall = Stream.concat(cycle.stream(), Stream.of(cycle.get(0)));
+        var unitCallNames = cycleWithDuplicatedFirstUnitCall.map(UnitCall::getName).collect(Collectors.toList());
+
+        return String.join(delimiter, unitCallNames);
     }
 }

--- a/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCyclesTests.java
+++ b/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCyclesTests.java
@@ -1,0 +1,305 @@
+package org.eclipse.sirius.web.services.validation.semantic.rules;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import eu.balticlsc.model.CAL.CALFactory;
+import eu.balticlsc.model.CAL.ComputationApplicationRelease;
+import eu.balticlsc.model.CAL.ComputationUnitRelease;
+import eu.balticlsc.model.CAL.ConnectableDataPin;
+import eu.balticlsc.model.CAL.DataBinding;
+import eu.balticlsc.model.CAL.DataFlow;
+import eu.balticlsc.model.CAL.UnitCall;
+
+public class NoDataFlowCyclesTests {
+    private DataFlowFactory dataFlowFactory;
+
+    private UnitCallFactory unitCallFactory;
+
+    private SinglePinUnitReleaseFactory singlePinUnitReleaseFactory;
+
+    private DoublePinUnitReleaseFactory doublePinUnitReleaseFactory;
+
+    @BeforeEach
+    public void init() {
+        this.dataFlowFactory = new DataFlowFactory();
+        this.unitCallFactory = new UnitCallFactory();
+        this.singlePinUnitReleaseFactory = new SinglePinUnitReleaseFactory();
+        this.doublePinUnitReleaseFactory = new DoublePinUnitReleaseFactory();
+    }
+
+    /**
+     * <p>
+     * The whole connection graph forms a cycle.
+     * </p>
+     * call 1 -> call 2 -> call 3 -> call 1
+     */
+    @Test
+    public void testLoopOf3Calls() {
+        var application = CALFactory.eINSTANCE.createComputationApplicationRelease();
+        var unitRelease = this.singlePinUnitReleaseFactory.createUnitRelease(application);
+
+        var call1 = this.unitCallFactory.createUnitCall(application, unitRelease, "Call 1"); //$NON-NLS-1$
+        var call2 = this.unitCallFactory.createUnitCall(application, unitRelease, "Call 2"); //$NON-NLS-1$
+        var call3 = this.unitCallFactory.createUnitCall(application, unitRelease, "Call 3"); //$NON-NLS-1$
+
+        // @formatter:off
+        // 1────►2────►3
+        // ▲           │
+        // └───────────┘
+        // @formatter:on
+        var flows = application.getFlows();
+        flows.add(this.dataFlowFactory.connectUnitCalls(call1, call2));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call2, call3));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call3, call1));
+
+        var rule = new NoDataFlowCycles();
+        var diagnostics = rule.validate(application);
+
+        assertThat(diagnostics).hasSize(1);
+        var expectedMessage = "Data flow must not form a cycle. Detected cycle: Call 1 -> Call 2 -> Call 3 -> Call 1"; //$NON-NLS-1$
+        assertThat(diagnostics.get(0).getMessage()).isEqualTo(expectedMessage);
+    }
+
+    @Test
+    public void testShortenedCycleAsPartOfGraph() {
+        var application = CALFactory.eINSTANCE.createComputationApplicationRelease();
+        var doublePinsUnitRelease = this.doublePinUnitReleaseFactory.createUnitRelease(application);
+
+        var call1 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 1"); //$NON-NLS-1$
+        var call2 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 2"); //$NON-NLS-1$
+        var call3 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 3"); //$NON-NLS-1$
+        var call4 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 4"); //$NON-NLS-1$
+        var call5 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 5"); //$NON-NLS-1$
+
+        // @formatter:off
+        //    ┌──►2────►4
+        //    │   │
+        // ┌►1│   │
+        // │  │   ▼
+        // │  └──►3 ───►5
+        // │            │
+        // └────────────┘
+        // @formatter:on
+        var flows = application.getFlows();
+        flows.add(this.dataFlowFactory.connectUnitCalls(call1, call2));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call1, call3));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call2, call3));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call2, call4));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call3, call5));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call5, call1));
+
+        var rule = new NoDataFlowCycles();
+        var diagnostics = rule.validate(application);
+
+        assertThat(diagnostics).hasSize(1);
+        // NOTE: this also makes sure that the reported cycle is shortened
+        // This will not ensure the the shortest cycle is found. This only checks the if a cycle
+        // is reported, it must be in its naively shortened representation (no extra immediate neighbors).
+        var expectedMessage = "Data flow must not form a cycle. Detected cycle: Call 1 -> Call 3 -> Call 5 -> Call 1"; //$NON-NLS-1$
+        assertThat(diagnostics.get(0).getMessage()).isEqualTo(expectedMessage);
+    }
+
+    @Test
+    public void testLoopIncludingAppliationDataPins() {
+        var application = CALFactory.eINSTANCE.createComputationApplicationRelease();
+        var doublePinsUnitRelease = this.doublePinUnitReleaseFactory.createUnitRelease(application);
+
+        // 1 and 2 are provided application data pins
+        // 6 is a required application data pin
+        // @formatter:off
+        // 1──────┬─────4
+        //        │     ▲
+        //        ▼     │
+        //        2────►3────►5
+        // @formatter:on
+
+        var applicationDataPin1 = CALFactory.eINSTANCE.createApplicationDataPin();
+        application.getApplicationDataPins().add(applicationDataPin1);
+        applicationDataPin1.setBinding(DataBinding.PROVIDED);
+        applicationDataPin1.setName("Appliation data pin 1"); //$NON-NLS-1$
+
+        var call2 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 2"); //$NON-NLS-1$
+        var call3 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 3"); //$NON-NLS-1$
+        var call4 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 4"); //$NON-NLS-1$
+
+        var applicationDataPin5 = CALFactory.eINSTANCE.createApplicationDataPin();
+        application.getApplicationDataPins().add(applicationDataPin5);
+        applicationDataPin5.setBinding(DataBinding.REQUIRED);
+        applicationDataPin5.setName("Appliation data pin 5"); //$NON-NLS-1$
+
+        var flows = application.getFlows();
+        flows.add(this.dataFlowFactory.connect(applicationDataPin1, this.dataFlowFactory.findDisconnectedRequiredPin(call2).get()));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call2, call3));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call3, call4));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call4, call2));
+        flows.add(this.dataFlowFactory.connect(this.dataFlowFactory.findDisconnectedProvidedPin(call3).get(), applicationDataPin5));
+
+        var rule = new NoDataFlowCycles();
+        var diagnostics = rule.validate(application);
+
+        assertThat(diagnostics).hasSize(1);
+        var expectedMessage = "Data flow must not form a cycle. Detected cycle: Call 2 -> Call 3 -> Call 4 -> Call 2"; //$NON-NLS-1$
+        assertThat(diagnostics.get(0).getMessage()).isEqualTo(expectedMessage);
+    }
+
+    @Test
+    public void testNoDiagnosticsInValidGraph() {
+        var application = CALFactory.eINSTANCE.createComputationApplicationRelease();
+        var doublePinsUnitRelease = this.doublePinUnitReleaseFactory.createUnitRelease(application);
+
+        var call1 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 1"); //$NON-NLS-1$
+        var call2 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 2"); //$NON-NLS-1$
+        var call3 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 3"); //$NON-NLS-1$
+        var call4 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 4"); //$NON-NLS-1$
+        var call5 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 5"); //$NON-NLS-1$
+        var call6 = this.unitCallFactory.createUnitCall(application, doublePinsUnitRelease, "Call 6"); //$NON-NLS-1$
+
+        // @formatter:off
+        //  ┌──────►2───────►4──────┐
+        //  │       │        ▲      ▼
+        //  1       │        │      6
+        //  │       ▼        │      ▲
+        //  └──────►3───────►5──────┘
+        // @formatter:on
+        var flows = application.getFlows();
+        flows.add(this.dataFlowFactory.connectUnitCalls(call1, call2));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call1, call3));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call2, call3));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call2, call4));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call3, call5));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call5, call4));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call4, call6));
+        flows.add(this.dataFlowFactory.connectUnitCalls(call5, call6));
+
+        var rule = new NoDataFlowCycles();
+        var diagnostics = rule.validate(application);
+
+        assertThat(diagnostics).isEmpty();
+    }
+
+    private class DataFlowFactory {
+        /**
+         * Attempts to connect 2 unit calls. Chooses data pins automatically by finding unused ones.
+         */
+        public DataFlow connectUnitCalls(UnitCall source, UnitCall target) {
+            var providedPin = this.findDisconnectedProvidedPin(source);
+            assertThat(providedPin.isPresent()).isTrue();
+
+            var requiredPin = this.findDisconnectedRequiredPin(target);
+            assertThat(requiredPin.isPresent()).isTrue();
+
+            return this.connect(providedPin.get(), requiredPin.get());
+        }
+
+        public DataFlow connect(ConnectableDataPin source, ConnectableDataPin target) {
+            var dataFlow = CALFactory.eINSTANCE.createDataFlow();
+            dataFlow.setSource(source);
+            dataFlow.setTarget(target);
+
+            return dataFlow;
+        }
+
+        public Optional<ConnectableDataPin> findDisconnectedProvidedPin(UnitCall call) {
+            // @formatter:off
+            return call.getPins()
+                .stream()
+                .filter(pin -> pin.getDataPin().getBinding() == DataBinding.PROVIDED && pin.getOutgoing() == null)
+                .map(ConnectableDataPin.class::cast)
+                .findFirst();
+            // @formatter:on
+        }
+
+        public Optional<ConnectableDataPin> findDisconnectedRequiredPin(UnitCall call) {
+            // @formatter:off
+            return call.getPins()
+                .stream()
+                .filter(pin -> pin.getDataPin().getBinding() == DataBinding.REQUIRED && pin.getIncoming() == null)
+                .map(ConnectableDataPin.class::cast)
+                .findFirst();
+            // @formatter:on
+        }
+    }
+
+    private class UnitCallFactory {
+        public UnitCall createUnitCall(ComputationApplicationRelease application, ComputationUnitRelease unitRelease, String name) {
+            var call = CALFactory.eINSTANCE.createUnitCall();
+            call.setUnit(unitRelease);
+
+            var calls = application.getCalls();
+            call.setName(name);
+            calls.add(call);
+
+            return call;
+        }
+    }
+
+    private class SinglePinUnitReleaseFactory {
+        /**
+         * <p>
+         * Returns a unit release with a single input and a single output data pin.
+         * </p>
+         */
+        public ComputationUnitRelease createUnitRelease(ComputationApplicationRelease application) {
+            var unitRelease = CALFactory.eINSTANCE.createComputationUnitRelease();
+            unitRelease.setName("Single input/output pin"); //$NON-NLS-1$
+            unitRelease.setVersion("0.1"); //$NON-NLS-1$
+            var pins = unitRelease.getDeclaredPins();
+
+            var inputPin = CALFactory.eINSTANCE.createDeclaredDataPin();
+            inputPin.setName("Input"); //$NON-NLS-1$
+            inputPin.setBinding(DataBinding.REQUIRED);
+            pins.add(inputPin);
+
+            var outputPin = CALFactory.eINSTANCE.createDeclaredDataPin();
+            outputPin.setName("Output"); //$NON-NLS-1$
+            outputPin.setBinding(DataBinding.PROVIDED);
+            pins.add(outputPin);
+
+            application.getUnits().add(unitRelease);
+
+            return unitRelease;
+        }
+    }
+
+    private class DoublePinUnitReleaseFactory {
+        /**
+         * <p>
+         * Returns a unit release with two input and two output data pins.
+         * </p>
+         */
+        public ComputationUnitRelease createUnitRelease(ComputationApplicationRelease application) {
+            var unitRelease = CALFactory.eINSTANCE.createComputationUnitRelease();
+            unitRelease.setName("Double input/output pin"); //$NON-NLS-1$
+            unitRelease.setVersion("0.1"); //$NON-NLS-1$
+            var pins = unitRelease.getDeclaredPins();
+
+            var inputPin1 = CALFactory.eINSTANCE.createDeclaredDataPin();
+            inputPin1.setName("Input 1"); //$NON-NLS-1$
+            inputPin1.setBinding(DataBinding.REQUIRED);
+            pins.add(inputPin1);
+
+            var inputPin2 = CALFactory.eINSTANCE.createDeclaredDataPin();
+            inputPin2.setName("Input 2"); //$NON-NLS-1$
+            inputPin2.setBinding(DataBinding.REQUIRED);
+            pins.add(inputPin2);
+
+            var outputPin1 = CALFactory.eINSTANCE.createDeclaredDataPin();
+            outputPin1.setName("Output 1"); //$NON-NLS-1$
+            outputPin1.setBinding(DataBinding.PROVIDED);
+            pins.add(outputPin1);
+
+            var outputPin2 = CALFactory.eINSTANCE.createDeclaredDataPin();
+            outputPin2.setName("Output 2"); //$NON-NLS-1$
+            outputPin2.setBinding(DataBinding.PROVIDED);
+            pins.add(outputPin2);
+
+            application.getUnits().add(unitRelease);
+
+            return unitRelease;
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the `NoDataFlowCycles` validation rule and adds unit tests for it.

The rule uses Depth-First Search in the graph of connections to find any cycle. If it is found, the rule attempt to naively shorten the cycle so triplets of consecutive nodes `a`, `b`, `c` on the cycle, where connections `a -> b` and `a -> c` exist, are transformed to `a, c` (the middle `b` node is removed from the cycle because it is not significant). See #68 for an example of this process. This is not the most robust solution to shortening the cycle and it can be improved in #68 (see the description for details).

The diagnostic information shown in the UI includes also the cycle path, so it is easier to find the cycle for CAL-web users:

![image](https://user-images.githubusercontent.com/889383/142723153-925d0f7d-686c-4065-b375-86b381afc946.png)

Closes #26 