### PR TITLE
Thesis paper writing setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,11 @@
-name: Build
+name: Build application
 on:
   push:
     branches:
       - main
   pull_request:
+    paths-ignore:
+      - "paper/**"
 
 jobs:
   build_frontend:

--- a/.github/workflows/paper.yml
+++ b/.github/workflows/paper.yml
@@ -1,0 +1,25 @@
+name: Build thesis paper
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "paper/**"
+
+jobs:
+  build_paper:
+    name: Build thesis paper
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Compile LaTeX document
+        uses: xu-cheng/latex-action@v2
+        with:
+          root_file: main.tex
+          working_directory: paper/
+      - name: Upload compiled PDF
+        uses: actions/upload-artifact@v2
+        with:
+          name: thesis-paper
+          path: paper/main.pdf

--- a/paper/.gitignore
+++ b/paper/.gitignore
@@ -1,0 +1,6 @@
+*.aux
+*.fdb_latexmk
+*.fls
+*.log
+*.synctex.gz
+*.pdf

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -1,0 +1,14 @@
+\documentclass{article}
+\usepackage[T1]{fontenc}
+
+\begin{document}
+
+First document. This is a sample to test that compilation indeed works fine.
+Polskie znaki także powinny działać: łńęźżć
+
+\end{document}
+
+% vim: tw=80
+\end{document}
+
+% vim: tw=80


### PR DESCRIPTION
Configure the repository in a way that makes it easy to write the thesis paper:

* add `.gitignore` for the thesis paper
* add a GitHub workflow that compiles the thesis paper and uploads it as a build artifact (see https://github.com/Gelio/CAL-web/actions/runs/1484738131 for an example)
* change GitHub workflow settings so they only run when specific files change 

    The thesis paper is built when anything in the `paper` directory is changed (confirmed by #75).
    The application is built when anything outside of the `paper` directory is changed (confirmed by #76).

    Both workflows run on the `main` branch.

Closes #72 