### PR TITLE
chore(thesis): configure texlab forward search

### DIFF
--- a/paper/.nvimrc
+++ b/paper/.nvimrc
@@ -13,6 +13,12 @@ lua <<EOF
     ["local"] = "latexindent.yaml",
     modifyLineBreaks = true
   }
+  texlab_settings.forwardSearch = {
+    executable = "zathura",
+    -- texlab does not support for current cursor column, so hardcode 1
+    -- so the format matches the one zathura expects
+    args = { "--synctex-forward", "%l:1:%f", "%p" },
+  }
 
   -- Reload the configuration
   require('lspconfig').texlab.setup(texlab_config)

--- a/paper/README.md
+++ b/paper/README.md
@@ -38,7 +38,9 @@ loaded and result in incorrect recognition of TeX files.
 #### Forward search
 
 For forward-search, install
-[the Zathura PDF viewer](https://pwmt.org/projects/zathura/documentation/).
+[the Zathura PDF viewer](https://pwmt.org/projects/zathura/documentation/). The
+reason is that the built-in PDF viewer is hard to configure to support forward-
+and inverse-search with support for project multiple files.
 
 On Ubuntu, you can install it using:
 
@@ -46,7 +48,7 @@ On Ubuntu, you can install it using:
 sudo apt install zathura
 ```
 
-Then, do `\lv` (or `:VimtexView`) to do forward search.
+Then, do `\lv` (or `:VimtexView`, or `:TexlabForward`) to do forward search.
 
 #### Inverse search
 


### PR DESCRIPTION
Use Zathura to forward search using texlab (`:TexlabForward`).