### PR TITLE
Modify the application to allow running in Heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,11 @@ COPY --from=app-builder /app/staging/ ./
 
 ENV PORT=8080
 
+# NOTE: running the application as non-root, as recommended by Heroku
+# https://devcenter.heroku.com/articles/container-registry-and-runtime#run-the-image-as-a-non-root-user
+RUN useradd -m user
+USER user
+
 # NOTE: Heroku requires listening on the port passed in the $PORT environment variable
 # Configuration can be passed in by mounting application.properties into `/app/application.properties`
 # NOTE: use shell to expand environment variables https://stackoverflow.com/a/40454758/4874344

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,9 @@ WORKDIR /app
 
 COPY --from=app-builder /app/staging/ ./
 
+ENV PORT=8080
+
+# NOTE: Heroku requires listening on the port passed in the $PORT environment variable
 # Configuration can be passed in by mounting application.properties into `/app/application.properties`
-CMD ["java", "-jar", "sirius-web-application.jar"]
+# NOTE: use shell to expand environment variables https://stackoverflow.com/a/40454758/4874344
+CMD ["sh", "-c", "java -jar sirius-web-application.jar --server.port=$PORT"]

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -20,5 +20,16 @@ module.exports = {
       ],
     ],
     "scope-empty": [1, "never"],
+    // NOTE: allow adding links in commit messages
+    // https://github.com/conventional-changelog/commitlint/issues/2112#issuecomment-690001646
+    "footer-max-line-length": [0, "always"],
+  },
+
+  parserPreset: {
+    parserOpts: {
+      // NOTE: allow adding links in commit messages
+      // https://github.com/conventional-changelog/commitlint/issues/2112#issuecomment-690001646
+      noteKeywords: ["link:"],
+    },
   },
 };


### PR DESCRIPTION
Adjust the configuration (only the `Dockerfile`) to allow running the application on Heroku. This only affects how the application is run in Docker.

Even though I am not using Heroku to run the application (see https://github.com/Gelio/CAL-web/issues/66#issuecomment-975849865), the changes do not break anything and maybe this makes the container more configurable. It may be run on Heroku one day.

Closes #66 

## Changes

1. The server will bind to the port specified by the `PORT` environment variable (`8080` by default, the same as when running outside of Docker)
2. The server will be run using a non-root user