### PR TITLE
Show onboard area after creating a project

### DIFF
--- a/backend/.nvimrc.lua
+++ b/backend/.nvimrc.lua
@@ -5,7 +5,16 @@ local base_dap_config = {
 	hostName = "127.0.0.1",
 	port = 8000,
 }
-local project_names = { "sirius-web-services", "sirius-web-services-api", "sirius-web-spring" }
+local project_names = {
+	"sirius-web-frontend",
+	"sirius-web-graphql",
+	"sirius-web-graphql-schema",
+	"sirius-web-persistence",
+	"sirius-web-sample-application",
+	"sirius-web-services",
+	"sirius-web-services-api",
+	"sirius-web-spring",
+}
 
 dap.configurations.java = vim.tbl_map(function(project_name)
 	return vim.tbl_extend("error", base_dap_config, {

--- a/frontend/src/views/edit-project/EditProjectView.tsx
+++ b/frontend/src/views/edit-project/EditProjectView.tsx
@@ -18,6 +18,10 @@ import { makeStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import CloseIcon from "@material-ui/icons/Close";
 import { useMachine } from "@xstate/react";
+import {
+  Representation,
+  Workbench as SiriusComponentsWorkbench,
+} from "@eclipse-sirius/sirius-components";
 import gql from "graphql-tag";
 import { useEffect } from "react";
 import {
@@ -39,6 +43,7 @@ import {
   HandleFetchedProjectEvent,
   HideToastEvent,
   SchemaValue,
+  SelectRepresentationEvent,
   ShowToastEvent,
 } from "./EditProjectViewMachine";
 import { Workbench } from "./Workbench";
@@ -145,12 +150,34 @@ export const EditProjectView = () => {
 
   let main = null;
   if (editProjectView === "loaded" && project) {
-    main = (
-      <Workbench
-        editingContextId={project.currentEditingContext.id}
-        representation={representation}
-      />
-    );
+    if (representation) {
+      main = (
+        <Workbench
+          editingContextId={project.currentEditingContext.id}
+          representation={representation}
+        />
+      );
+    } else {
+      // NOTE: the user needs to create a model in the project and a representation for it
+      // The `OnboardArea` component is not exposed in `sirius-components`
+      // (https://github.com/eclipse-sirius/sirius-components/issues/830#issuecomment-967976773),
+      // so we need to show the original `Workbench` component instead and
+      // switch to our one after the user selects a representation.
+      main = (
+        <SiriusComponentsWorkbench
+          editingContextId={project.currentEditingContext.id}
+          onRepresentationSelected={(newRepresentation: Representation) => {
+            const event: SelectRepresentationEvent = {
+              type: "SELECT_REPRESENTATION",
+              representation: newRepresentation,
+            };
+
+            dispatch(event);
+          }}
+          readOnly={false}
+        />
+      );
+    }
   } else if (editProjectView === "missing") {
     main = (
       <Grid container justifyContent="center" alignItems="center">


### PR DESCRIPTION
Right after creating the project, there are no models or representations in the project. The automation for it is not complete. The user is greeted with an unhelpful message about the representation being missing.

This commit changes it so that the user is shown the `OnboardArea` component instead and can create a model and a new representation for it. The moment the user selects a representation, they are dropped into our own `Workbench` with the toolbox.

The `OnboardArea` component is not exposed from sirius-components (https://github.com/eclipse-sirius/sirius-components/issues/830#issuecomment-967976773), so we need to show the original `Workbench` component instead and switch the components later. This is not great, because child comopnents lose state (for example, the explorer tree is collapsed after selecting a representation), but at least it works.

Closes #87


https://user-images.githubusercontent.com/889383/142995383-21d4b39e-3ec1-4cab-83fb-f8d5a8d777d7.mp4

