### PR TITLE
fix(auth): list only projects owned by the user

### DIFF
--- a/backend/sirius-web-persistence/src/main/resources/db/sirius-web-named-queries.properties
+++ b/backend/sirius-web-persistence/src/main/resources/db/sirius-web-named-queries.properties
@@ -1,7 +1,11 @@
 Project.getUserAccessLevel=SELECT 'ADMIN'::AccessLevel
+# Due to lack of WebSocket authentication (see https://github.com/eclipse-sirius/sirius-components/issues/846#issuecomment-981072654)
+# the username used in the `existsByIdAndIsVisibleBy` query is a hardcoded one, not the real user's one.
+# Thus, for WebSockets we assume there are no restrictions on accessing projects.
+# This is a security threat and is waiting for https://github.com/eclipse-sirius/sirius-components/issues/846
 Project.existsByIdAndIsVisibleBy=SELECT CASE WHEN COUNT(project)> 0 THEN true ELSE false END FROM project WHERE project.id=?1
-Project.findAllVisibleBy=SELECT * FROM project
-Project.findByIdIfVisibleBy=SELECT * FROM project project WHERE project.id=?1
+Project.findAllVisibleBy=SELECT * FROM project JOIN account ON project.owner_id = account.id WHERE account.username = ?1
+Project.findByIdIfVisibleBy=SELECT * FROM project JOIN account ON project.owner_id = account.id WHERE project.id = ?1 AND account.username = ?2
 Project.isOwner=SELECT CASE WHEN COUNT(project)> 0 THEN true ELSE false END FROM ProjectEntity project WHERE project.id=?2 AND project.owner.username=?1
 Document.findAllByType=SELECT * FROM Document document WHERE document.content::::jsonb @> ('{ "ns": { "' || ?1 || '": "' || ?2 ||'" } }')::::jsonb
 Representation.deleteDanglingRepresentations=DELETE FROM Representation representation WHERE representation.project_id=?1 AND NOT EXISTS (SELECT * FROM Document document WHERE document.project_id=?1 AND jsonb_path_exists(document.content::::jsonb, ('strict $.content.**.id ? (@ == "' || representation.targetobjectid || '" ) ')::::jsonpath))


### PR DESCRIPTION
Restrict projects shown the user to only the projects they own.

This is only respected for GraphQL queries, because only in that context do we know the actual username.

For GraphQL subscriptions, due to lack of support for WebSocket authentication
(https://github.com/eclipse-sirius/sirius-components/issues/846), there is no authentication.

Fixes #107


https://user-images.githubusercontent.com/889383/144206518-8270fe5b-9c2c-4e62-9ea8-b51d0b5bc740.mp4

