### PR TITLE
Relax metamodel bounds

### DIFF
--- a/backend/model/eu.balticlsc.model.CAL/model/CAL.aird
+++ b/backend/model/eu.balticlsc.model.CAL/model/CAL.aird
@@ -5,7 +5,7 @@
     <semanticResources>CAL.genmodel</semanticResources>
     <ownedViews xmi:type="viewpoint:DView" uid="_mUONIHHBEeuPSaKcLpzDWQ">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_mWVtAXHBEeuPSaKcLpzDWQ" name="CAL" repPath="#_mVcVIHHBEeuPSaKcLpzDWQ" changeId="c476c249-f34c-4032-9a34-e58533e4e5ae">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_mWVtAXHBEeuPSaKcLpzDWQ" name="CAL" repPath="#_mVcVIHHBEeuPSaKcLpzDWQ" changeId="1b5d5c4c-1a29-4524-b6de-4882bb128f5f">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']"/>
         <target xmi:type="ecore:EPackage" href="CAL.ecore#/"/>
       </ownedRepresentationDescriptors>
@@ -932,7 +932,7 @@
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_R3xYMBPBEeyRB6wGTmeTsQ" sourceNode="_2mCj4HHDEeuPSaKcLpzDWQ" targetNode="_1R76MHLgEeu3p4oiwrKNaQ" beginLabel="[1..*] calls" endLabel="[1..1] unit">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_R3xYMBPBEeyRB6wGTmeTsQ" sourceNode="_2mCj4HHDEeuPSaKcLpzDWQ" targetNode="_1R76MHLgEeu3p4oiwrKNaQ" beginLabel="[0..*] calls" endLabel="[1..1] unit">
       <target xmi:type="ecore:EReference" href="CAL.ecore#//UnitCall/unit"/>
       <semanticElements xmi:type="ecore:EReference" href="CAL.ecore#//ComputationUnitRelease/calls"/>
       <semanticElements xmi:type="ecore:EReference" href="CAL.ecore#//UnitCall/unit"/>

--- a/backend/model/eu.balticlsc.model.CAL/model/CAL.ecore
+++ b/backend/model/eu.balticlsc.model.CAL/model/CAL.ecore
@@ -41,7 +41,7 @@
         eType="#//UnitParameter" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EReference" name="declaredPins" upperBound="-1"
         eType="#//DeclaredDataPin" containment="true"/>
-    <eStructuralFeatures xsi:type="ecore:EReference" name="calls" lowerBound="1" upperBound="-1"
+    <eStructuralFeatures xsi:type="ecore:EReference" name="calls" upperBound="-1"
         eType="#//UnitCall" eOpposite="#//UnitCall/unit"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="UnitParameter">

--- a/backend/model/eu.balticlsc.model.CAL/src-gen/eu/balticlsc/model/CAL/ComputationUnitRelease.java
+++ b/backend/model/eu.balticlsc.model.CAL/src-gen/eu/balticlsc/model/CAL/ComputationUnitRelease.java
@@ -104,7 +104,7 @@ public interface ComputationUnitRelease extends EObject {
 	 * @return the value of the '<em>Calls</em>' reference list.
 	 * @see eu.balticlsc.model.CAL.CALPackage#getComputationUnitRelease_Calls()
 	 * @see eu.balticlsc.model.CAL.UnitCall#getUnit
-	 * @model opposite="unit" required="true"
+	 * @model opposite="unit"
 	 * @generated
 	 */
 	EList<UnitCall> getCalls();

--- a/backend/model/eu.balticlsc.model.CAL/src-gen/eu/balticlsc/model/CAL/impl/CALPackageImpl.java
+++ b/backend/model/eu.balticlsc.model.CAL/src-gen/eu/balticlsc/model/CAL/impl/CALPackageImpl.java
@@ -823,7 +823,7 @@ public class CALPackageImpl extends EPackageImpl implements CALPackage {
 		initEReference(getComputationUnitRelease_DeclaredPins(), this.getDeclaredDataPin(), null, "declaredPins", null,
 				0, -1, ComputationUnitRelease.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE,
 				!IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEReference(getComputationUnitRelease_Calls(), this.getUnitCall(), this.getUnitCall_Unit(), "calls", null, 1,
+		initEReference(getComputationUnitRelease_Calls(), this.getUnitCall(), this.getUnitCall_Unit(), "calls", null, 0,
 				-1, ComputationUnitRelease.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_COMPOSITE,
 				IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 


### PR DESCRIPTION
Do not require all `ComputationUnitRelease` to be used.

`DataFlow`s are more meaningful, in my opinion, and thus, they should not be left dangling. Thus, this bound was not relaxed. IMO users should still inspect the data flows they have in the model and make sure they have sense. Having all data flows be valid in the model will make the model processing when integrating with other systems easier because flows would not have to be checked if they are connected first.

Closes #48