### PR TITLE
Report connections graph cycles as warnings

### DIFF
--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCycles.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCycles.java
@@ -27,10 +27,10 @@ public class NoDataFlowCycles implements ISemanticCALValidationRule {
         // @formatter:off
         return this.findCycle(applicationRelease)
             .map(cycle -> new BasicDiagnostic(
-                Diagnostic.ERROR,
+                Diagnostic.WARNING,
                 String.valueOf(cycle.hashCode()),
                 1,
-                String.format("Data flow must not form a cycle. Detected cycle: %s", this.formatCycle(cycle)), //$NON-NLS-1$
+                String.format("Data flow forms a cycle. This could be (but does not have to be) a mistake. Detected cycle: %s", this.formatCycle(cycle)), //$NON-NLS-1$
                 new Object[0]
             ))
             .stream()

--- a/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCyclesTests.java
+++ b/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/validation/semantic/rules/NoDataFlowCyclesTests.java
@@ -1,5 +1,6 @@
 package org.eclipse.sirius.web.services.validation.semantic.rules;
 
+import org.eclipse.emf.common.util.Diagnostic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,7 +63,8 @@ public class NoDataFlowCyclesTests {
         var diagnostics = rule.validate(application);
 
         assertThat(diagnostics).hasSize(1);
-        var expectedMessage = "Data flow must not form a cycle. Detected cycle: Call 1 -> Call 2 -> Call 3 -> Call 1"; //$NON-NLS-1$
+        assertThat(diagnostics.get(0).getSeverity()).isEqualTo(Diagnostic.WARNING);
+        var expectedMessage = "Data flow forms a cycle. This could be (but does not have to be) a mistake. Detected cycle: Call 1 -> Call 2 -> Call 3 -> Call 1"; //$NON-NLS-1$
         assertThat(diagnostics.get(0).getMessage()).isEqualTo(expectedMessage);
     }
 
@@ -101,7 +103,7 @@ public class NoDataFlowCyclesTests {
         // NOTE: this also makes sure that the reported cycle is shortened
         // This will not ensure the the shortest cycle is found. This only checks the if a cycle
         // is reported, it must be in its naively shortened representation (no extra immediate neighbors).
-        var expectedMessage = "Data flow must not form a cycle. Detected cycle: Call 1 -> Call 3 -> Call 5 -> Call 1"; //$NON-NLS-1$
+        var expectedMessage = "Data flow forms a cycle. This could be (but does not have to be) a mistake. Detected cycle: Call 1 -> Call 3 -> Call 5 -> Call 1"; //$NON-NLS-1$
         assertThat(diagnostics.get(0).getMessage()).isEqualTo(expectedMessage);
     }
 
@@ -144,7 +146,7 @@ public class NoDataFlowCyclesTests {
         var diagnostics = rule.validate(application);
 
         assertThat(diagnostics).hasSize(1);
-        var expectedMessage = "Data flow must not form a cycle. Detected cycle: Call 2 -> Call 3 -> Call 4 -> Call 2"; //$NON-NLS-1$
+        var expectedMessage = "Data flow forms a cycle. This could be (but does not have to be) a mistake. Detected cycle: Call 2 -> Call 3 -> Call 4 -> Call 2"; //$NON-NLS-1$
         assertThat(diagnostics.get(0).getMessage()).isEqualTo(expectedMessage);
     }
 


### PR DESCRIPTION
Cycles in the connections graph could be a mistake, but they do not have to be. A warning seems like a good enough severity that will not be misleading users into believing they are doing something forbidden.

The text of the warning is also changed to suggest that this could be a mistake, but does not have to be.

Closes #106

![image](https://user-images.githubusercontent.com/889383/144722099-d18b832a-775e-4537-86b2-fe3c6b5437de.png)
