### PR TITLE
Show auth-related GraphQL errors toast

### DIFF
--- a/frontend/src/auth/apollo-links.ts
+++ b/frontend/src/auth/apollo-links.ts
@@ -1,12 +1,20 @@
 import * as O from "fp-ts/lib/Option";
 import { onError } from "@apollo/client/link/error";
+import { useAuthErrorStore } from "./error";
+import { ServerError } from "@apollo/client";
 
 export const getAuthHeaders = (token: O.Option<string>) => ({
   Authorization: O.isSome(token) ? `Bearer ${token.value}` : undefined,
 });
 
 export const getAuthErrorLink = () =>
-  onError(({ graphQLErrors, networkError }) => {
-    console.log({ graphQLErrors, networkError });
-    // TODO: show an error
+  onError(({ networkError }) => {
+    if (networkError && isServerError(networkError)) {
+      if (networkError.statusCode === 401 || networkError.statusCode === 403) {
+        useAuthErrorStore.getState().setError(networkError);
+      }
+    }
   });
+
+const isServerError = (error: Error): error is ServerError =>
+  error.name === "ServerError";

--- a/frontend/src/auth/error.ts
+++ b/frontend/src/auth/error.ts
@@ -1,0 +1,13 @@
+import type { ServerError } from "@apollo/client";
+import * as O from "fp-ts/lib/Option";
+import create from "zustand";
+
+export interface AuthErrorStore {
+  error: O.Option<ServerError>;
+  setError: (error: ServerError) => void;
+}
+
+export const useAuthErrorStore = create<AuthErrorStore>((set) => ({
+  error: O.none,
+  setError: (error) => set({ error: O.some(error) }),
+}));


### PR DESCRIPTION
Add a toast notification that is shown when there are authentication-related GraphQL errors.

It is not triggered in all cases that the JWT may be invalid. For example, for malformed JWTs the 400 status code is returned from the backend. This will not trigger the authentication-only toast notification.

Closes #103

![image](https://user-images.githubusercontent.com/889383/144722939-b3605ae6-61e6-4dd5-97f8-b2fe47b00831.png)

Notice the toast in the bottom left corner of the screen.