### PR TITLE
Remove unnecessary model modifications flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Based on [sirius-web](https://github.com/eclipse-sirius/sirius-web).
   - [Running the application](#running-the-application)
   - [Configuring the application](#configuring-the-application)
   - [Debugging the application](#debugging-the-application)
-  - [Enabling experimental model modifications](#enabling-experimental-model-modifications)
   - [Building and running the application with Docker](#building-and-running-the-application-with-docker)
   - [Using Docker Compose to run the application](#using-docker-compose-to-run-the-application)
 - [Keeping up with the upstream `sirius-web`](#keeping-up-with-the-upstream-sirius-web)
@@ -89,7 +88,7 @@ To configure the properties, do one of the following:
 - pass the properties to the `launch.sh` script:
 
   ```sh
-  ./backend/scripts/launch.sh --eu.balticlsc.model.features.modificationsEnabled=true
+  ./backend/scripts/launch.sh --logging.level.org.eclipse.sirius.web=debug
   ```
 
 - create an `application.properties` file in the current directory and launch
@@ -118,23 +117,6 @@ configuration. For neovim, there is an
 
 See [`launch-debug.sh`](./backend/scripts/launch-debug.sh) for details of debug
 settings.
-
-### Enabling experimental model modifications
-
-To enable experimental model modifications, pass the
-`--eu.balticlsc.model.features.modificationsEnabled=true` flag to the
-`launch.sh` or `launch-debug.sh` script:
-
-```sh
-./backend/scripts/launch.sh --eu.balticlsc.model.features.modificationsEnabled=true
-```
-
-This will run the application with experimental model modifications. This means
-that when loading the model, there will be an extra `ComputationUnitRelease`
-added to the model.
-
-The change is not meaningful right now, but it shows it is possible to modify
-the model programmatically when it is being loaded.
 
 ### Building and running the application with Docker
 

--- a/backend/sirius-web-sample-application/src/main/resources/application.properties
+++ b/backend/sirius-web-sample-application/src/main/resources/application.properties
@@ -25,8 +25,6 @@ logging.level.org.eclipse.sirius.web=debug
 
 sirius.components.cors.allowedOriginPatterns=*
 
-eu.balticlsc.model.features.modificationsEnabled=false
-
 eu.balticlsc.api-proxy.scheme=https
 eu.balticlsc.api-proxy.hostname=balticlsc.iem.pw.edu.pl
 eu.balticlsc.api-proxy.port=443

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextPersistenceService.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextPersistenceService.java
@@ -62,16 +62,11 @@ public class EditingContextPersistenceService implements IEditingContextPersiste
 
     private final Timer timer;
 
-    private final boolean modelModificationsEnabled;
-
-    public EditingContextPersistenceService(IDocumentRepository documentRepository,
-            ApplicationEventPublisher applicationEventPublisher, MeterRegistry meterRegistry,
-            @Value("${eu.balticlsc.model.features.modificationsEnabled:false}") boolean modelModificationsEnabled) {
+    public EditingContextPersistenceService(IDocumentRepository documentRepository, ApplicationEventPublisher applicationEventPublisher, MeterRegistry meterRegistry) {
         this.documentRepository = Objects.requireNonNull(documentRepository);
         this.applicationEventPublisher = Objects.requireNonNull(applicationEventPublisher);
 
         this.timer = Timer.builder(TIMER_NAME).register(meterRegistry);
-        this.modelModificationsEnabled = modelModificationsEnabled;
     }
 
     @Override
@@ -102,11 +97,6 @@ public class EditingContextPersistenceService implements IEditingContextPersiste
         Optional<DocumentEntity> result = Optional.empty();
         HashMap<Object, Object> options = new HashMap<>();
         options.put(JsonResource.OPTION_ID_MANAGER, new EObjectIDManager());
-
-        if (this.modelModificationsEnabled) {
-            this.logger.debug("Saving a resource {}", resource.toString());
-            // TODO: remove unused auto-generated ComputationUnitReleases
-        }
 
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             resource.save(outputStream, options);

--- a/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchService.java
+++ b/backend/sirius-web-services/src/main/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchService.java
@@ -73,12 +73,8 @@ public class EditingContextSearchService implements IEditingContextSearchService
 
     private final Timer timer;
 
-    private final boolean modelModificationsEnabled;
-
-    public EditingContextSearchService(IProjectRepository projectRepository, IDocumentRepository documentRepository,
-            IEditingContextEPackageService editingContextEPackageService, ComposedAdapterFactory composedAdapterFactory,
-            EPackage.Registry globalEPackageRegistry, MeterRegistry meterRegistry,
-            @Value("${eu.balticlsc.model.features.modificationsEnabled:false}") boolean modelModificationsEnabled) {
+    public EditingContextSearchService(IProjectRepository projectRepository, IDocumentRepository documentRepository, IEditingContextEPackageService editingContextEPackageService,
+            ComposedAdapterFactory composedAdapterFactory, EPackage.Registry globalEPackageRegistry, MeterRegistry meterRegistry) {
         this.projectRepository = Objects.requireNonNull(projectRepository);
         this.documentRepository = Objects.requireNonNull(documentRepository);
         this.editingContextEPackageService = Objects.requireNonNull(editingContextEPackageService);
@@ -86,7 +82,6 @@ public class EditingContextSearchService implements IEditingContextSearchService
         this.globalEPackageRegistry = Objects.requireNonNull(globalEPackageRegistry);
 
         this.timer = Timer.builder(TIMER_NAME).register(meterRegistry);
-        this.modelModificationsEnabled = modelModificationsEnabled;
     }
 
     @Override
@@ -121,24 +116,6 @@ public class EditingContextSearchService implements IEditingContextSearchService
                 resource.load(inputStream, null);
 
                 resource.eAdapters().add(new DocumentMetadataAdapter(documentEntity.getName()));
-
-                if (this.modelModificationsEnabled) {
-                    for (var obj : resource.getContents()) {
-                        // TODO: add ComputationUnitReleases
-                        this.logger.debug("Resource {}", obj.toString());
-                        if (obj instanceof ComputationApplicationRelease) {
-                            var computationApplication = (ComputationApplicationRelease) obj;
-                            var unit = CALFactory.eINSTANCE.createComputationUnitRelease();
-                            unit.setName("Auto-generated");
-                            computationApplication.getUnits().add(unit);
-                            try {
-                                this.logger.debug("Sleeping to simulate a network call");
-                                Thread.sleep(5000);
-                            } catch (Exception e) {
-                            }
-                        }
-                    }
-                }
             } catch (IOException | IllegalArgumentException exception) {
                 this.logger.warn("An error occured while loading document {}: {}.", documentEntity.getId(), exception.getMessage()); //$NON-NLS-1$
                 resourceSet.getResources().remove(resource);

--- a/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextPersistenceServiceTests.java
+++ b/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextPersistenceServiceTests.java
@@ -87,8 +87,7 @@ public class EditingContextPersistenceServiceTests {
                 return Optional.of(existingEntity);
             }
         };
-        IEditingContextPersistenceService editingContextPersistenceService = new EditingContextPersistenceService(
-                documentRepository, new NoOpApplicationEventPublisher(), new SimpleMeterRegistry(), false);
+        IEditingContextPersistenceService editingContextPersistenceService = new EditingContextPersistenceService(documentRepository, new NoOpApplicationEventPublisher(), new SimpleMeterRegistry());
         assertThat(entities).hasSize(0);
 
         IEditingContext editingContext = new EditingContext(UUID.randomUUID(), editingDomain);

--- a/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchServiceTests.java
+++ b/backend/sirius-web-services/src/test/java/org/eclipse/sirius/web/services/editingcontext/EditingContextSearchServiceTests.java
@@ -85,9 +85,8 @@ public class EditingContextSearchServiceTests {
         UUID projectId = UUID.randomUUID();
 
         IEditingContextEPackageService editingContextEPackageService = editingContextId -> List.of();
-        IEditingContextSearchService editingContextSearchService = new EditingContextSearchService(projectRepository,
-                documentRepository, editingContextEPackageService, composedAdapterFactory, ePackageRegistry,
-                new SimpleMeterRegistry(), false);
+        IEditingContextSearchService editingContextSearchService = new EditingContextSearchService(projectRepository, documentRepository, editingContextEPackageService, composedAdapterFactory,
+                ePackageRegistry, new SimpleMeterRegistry());
         IEditingContext editingContext = editingContextSearchService.findById(projectId).get();
 
         assertThat(editingContext).isInstanceOf(EditingContext.class);
@@ -128,9 +127,8 @@ public class EditingContextSearchServiceTests {
         ePackageRegistry.put(EcorePackage.eNS_URI, EcorePackage.eINSTANCE);
 
         IEditingContextEPackageService editingContextEPackageService = editingContextId -> List.of();
-        IEditingContextSearchService editingContextSearchService = new EditingContextSearchService(projectRepository,
-                documentRepository, editingContextEPackageService, composedAdapterFactory, ePackageRegistry,
-                new SimpleMeterRegistry(), false);
+        IEditingContextSearchService editingContextSearchService = new EditingContextSearchService(projectRepository, documentRepository, editingContextEPackageService, composedAdapterFactory,
+                ePackageRegistry, new SimpleMeterRegistry());
         IEditingContext editingContext = editingContextSearchService.findById(projectId).get();
 
         assertThat(editingContext).isInstanceOf(EditingContext.class);


### PR DESCRIPTION
The model modifications done on load were not used.

The idea was to load all ComputationUnitReleases into the model at that point. However, during the project, it was decided that having a BalticLSC-like toolbox of ComputationUnitReleases is a better idea. Thus, model modifications are not needed.

Closes #79