### PR TITLE
Refresh toolbox button

### DIFF
--- a/frontend/src/views/edit-project/Workbench/Toolbox/Toolbox.tsx
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/Toolbox.tsx
@@ -2,7 +2,14 @@ import * as O from "fp-ts/lib/Option";
 import * as E from "fp-ts/lib/Either";
 import { UseToolboxEntryButton } from "./UseToolboxEntryButton";
 import { useRootObjectId } from "./root-object-id";
-import { CircularProgress, styled, Typography } from "@material-ui/core";
+import {
+  CircularProgress,
+  IconButton,
+  styled,
+  Tooltip,
+  Typography,
+} from "@material-ui/core";
+import RefreshIcon from "@material-ui/icons/Refresh";
 import { useBalticLSCToolboxEntries } from "./use-balticlsc-toolbox-entries";
 import { TokenStore, useTokenStore } from "../../../../auth";
 
@@ -14,12 +21,15 @@ const tokenSelector = ({ token }: TokenStore) => token;
 
 export const Toolbox = ({ editingContextId }: ToolboxProps) => {
   const token = useTokenStore(tokenSelector);
-  const { error, loading, toolboxEntries } = useBalticLSCToolboxEntries(token);
+  const { error, loading, toolboxEntries, refresh } =
+    useBalticLSCToolboxEntries(token);
   const rootObjectIdResOpt = useRootObjectId(editingContextId);
 
   return (
     <ToolboxContainer>
-      {/* TODO: add a button to refresh the entries https://github.com/Gelio/CAL-web/issues/50 */}
+      <RefreshToolboxButtonContainer>
+        <RefreshToolboxButton disabled={loading} onClick={refresh} />
+      </RefreshToolboxButtonContainer>
 
       {O.isNone(rootObjectIdResOpt) || loading ? (
         <CircularProgress />
@@ -64,3 +74,30 @@ const ToolboxContainer = styled("div")(({ theme }) => ({
   alignItems: "center",
   flexWrap: "wrap",
 }));
+
+const RefreshToolboxButtonContainer = styled("div")(({ theme }) => ({
+  marginRight: theme.spacing(1),
+  borderRight: `solid 1px ${theme.palette.divider}`,
+  borderBottom: `solid 1px ${theme.palette.divider}`,
+  borderBottomRightRadius: 8,
+}));
+interface RefreshToolboxButtonProps {
+  onClick: () => void;
+  disabled: boolean;
+}
+const RefreshToolboxButton = ({
+  onClick,
+  disabled,
+}: RefreshToolboxButtonProps) => {
+  return (
+    <Tooltip title="Refresh toolbox">
+      <IconButton
+        onClick={onClick}
+        disabled={disabled}
+        aria-label="Refresh toolbox"
+      >
+        <RefreshIcon />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/frontend/src/views/edit-project/Workbench/Toolbox/use-balticlsc-toolbox-entries.ts
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/use-balticlsc-toolbox-entries.ts
@@ -1,4 +1,5 @@
 import * as TE from "fp-ts/lib/TaskEither";
+import * as T from "fp-ts/lib/Task";
 import * as O from "fp-ts/lib/Option";
 import { pipe } from "fp-ts/lib/function";
 import { ToolboxEntry } from "./interop";
@@ -87,11 +88,11 @@ export const useBalticLSCToolboxEntries = (authToken: O.Option<string>) => {
         abortSignal: abortController.signal,
         balticLSCAPIUrl,
       }),
-      TE.apFirst(TE.fromIO(() => setLoading(false))),
       TE.match(setError, (entries) => {
         setToolboxEntries(entries);
         setError(undefined);
-      })
+      }),
+      T.map(() => setLoading(false))
     );
     runFetch();
 

--- a/frontend/src/views/edit-project/Workbench/Toolbox/use-balticlsc-toolbox-entries.ts
+++ b/frontend/src/views/edit-project/Workbench/Toolbox/use-balticlsc-toolbox-entries.ts
@@ -71,6 +71,9 @@ export const useBalticLSCToolboxEntries = (authToken: O.Option<string>) => {
     ToolboxEntry[] | undefined
   >();
   const balticLSCAPIUrl = useAPIURLsStore(balticLSCAPIUrlSelector);
+  const [refreshId, setRefreshId] = useState(Math.random);
+
+  const refresh = () => setRefreshId(Math.random());
 
   useEffect(() => {
     if (O.isNone(authToken)) {
@@ -97,7 +100,7 @@ export const useBalticLSCToolboxEntries = (authToken: O.Option<string>) => {
     runFetch();
 
     return () => abortController.abort();
-  }, [authToken, balticLSCAPIUrl]);
+  }, [authToken, balticLSCAPIUrl, refreshId]);
 
-  return { error, loading, toolboxEntries };
+  return { error, loading, toolboxEntries, refresh };
 };


### PR DESCRIPTION
Add a button that refreshes the toolbox. Gives user the control to modify the toolbox in another tab/window and then see the updated contents without refreshing the whole workbench tab and losing context.

This PR also fixes a bug with the toolbox loading indicator being turned off faster than it should be.

Closes #50 


https://user-images.githubusercontent.com/889383/144755855-de182530-4036-4510-b7a3-97d95e672356.mp4

