### PR TITLE
Show token details and parsing errors in the UI

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@material-ui/styles": "^4.11.4",
         "@swc/helpers": "^0.2.14",
         "@xstate/react": "1.5.1",
+        "date-fns": "^2.27.0",
         "fontsource-roboto": "4.0.0",
         "fp-ts": "^2.11.5",
         "graphql": "15.5.1",
@@ -12080,6 +12081,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz",
+      "integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -41856,6 +41869,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.27.0.tgz",
+      "integrity": "sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q=="
     },
     "debug": {
       "version": "4.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "@material-ui/styles": "^4.11.4",
     "@swc/helpers": "^0.2.14",
     "@xstate/react": "1.5.1",
+    "date-fns": "^2.27.0",
     "fontsource-roboto": "4.0.0",
     "fp-ts": "^2.11.5",
     "graphql": "15.5.1",

--- a/frontend/src/auth/controls/AuthTokenDetails.tsx
+++ b/frontend/src/auth/controls/AuthTokenDetails.tsx
@@ -1,0 +1,136 @@
+import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
+import {
+  getTokenExpiryDate,
+  getTokenPayload,
+  getTokenVerificationErrorTitle,
+  TokenDecodeError,
+  TokenExpiryVerificationError,
+} from "../is-token-expired";
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import { pipe } from "fp-ts/lib/function";
+import { formatDistanceToNowStrict } from "date-fns";
+import { Typography } from "@material-ui/core";
+
+interface AuthTokenDetailsProps {
+  token: string;
+}
+
+export const AuthTokenDetails = ({ token }: AuthTokenDetailsProps) => {
+  const [details, setDetails] = useState<
+    O.Option<E.Either<TokenDecodeError | TokenExpiryVerificationError, Details>>
+  >(() => parseToken(token));
+
+  const debouncedSetDetails = useMemo(
+    () => debounce((token: string) => pipe(parseToken(token), setDetails)),
+    []
+  );
+
+  useEffect(() => {
+    debouncedSetDetails(token);
+  }, [token, debouncedSetDetails]);
+
+  if (O.isNone(details)) {
+    return <>Empty token</>;
+  }
+
+  if (E.isLeft(details.value)) {
+    return <>Error: {getTokenVerificationErrorTitle(details.value.left)}</>;
+  } else {
+    const unwrappedDetails = details.value.right;
+    return (
+      <>
+        <Typography variant="body2" gutterBottom>
+          Username: {unwrappedDetails.username}
+        </Typography>
+        <Typography variant="body2">
+          <Refresher value={unwrappedDetails.expiryDate}>
+            {() =>
+              `${
+                unwrappedDetails.expiryDate.getTime() <= Date.now()
+                  ? "Expired"
+                  : "Expires"
+              } ${formatDistanceToNowStrict(unwrappedDetails.expiryDate, {
+                addSuffix: true,
+              })}`
+            }
+          </Refresher>
+        </Typography>
+      </>
+    );
+  }
+};
+
+interface Details {
+  username: unknown;
+  expiryDate: Date;
+}
+
+const debounce = <F extends (...arg: any[]) => any>(f: F, waitMs = 500) => {
+  let timer: O.Option<number> = O.none;
+
+  return (...args: Parameters<F>): void => {
+    if (O.isSome(timer)) {
+      clearTimeout(timer.value);
+    }
+
+    timer = O.some(
+      // NOTE: use `window` prefix because of type mismatch coming from
+      // `@types/node`
+      window.setTimeout(() => {
+        f(...args);
+        timer = O.none;
+      }, waitMs)
+    );
+  };
+};
+
+const parseToken = (
+  tokenArg: string
+): O.Option<
+  E.Either<TokenDecodeError | TokenExpiryVerificationError, Details>
+> =>
+  pipe(
+    O.fromNullable(tokenArg),
+    O.filter((token) => token.length > 0),
+    O.map((token) =>
+      pipe(
+        E.Do,
+        E.bind("payload", () => getTokenPayload(token)),
+        E.bindW("expiryDate", ({ payload }) => getTokenExpiryDate(payload)),
+        E.map(
+          ({ payload, expiryDate }): Details => ({
+            username: payload.sub,
+            expiryDate,
+          })
+        )
+      )
+    )
+  );
+
+interface RefresherProps<T> {
+  value: T;
+  children: (value: T) => ReactNode;
+  intervalMs?: number;
+}
+/**
+ * Refreshes content on an interval. Makes sure relative dates are
+ * accurate.
+ */
+const Refresher = <T extends any>({
+  value,
+  children: updater,
+  intervalMs = 1000,
+}: RefresherProps<T>) => {
+  const [computedValue, setComputedValue] = useState(() => updater(value));
+
+  useEffect(() => {
+    setComputedValue(updater(value));
+    const intervalRef = setInterval(() => {
+      setComputedValue(updater(value));
+    }, intervalMs);
+    return () => clearInterval(intervalRef);
+  }, [value, intervalMs, updater]);
+
+  return <>{computedValue}</>;
+};


### PR DESCRIPTION
Display auth JWT parsing status in the model used to change it. Show the username and when the token expires. Display parsing errors, if any.

The expiry date is displayed relatively to now (e.g. "in 5 minutes"). There is a `Refresher` component that updates the UI every second to make sure this time distance stays accurate even if the modal is shown longer.

Closes #102
Closes #105

![image](https://user-images.githubusercontent.com/889383/144760670-7026e243-61b2-4f65-b470-427da1faf74b.png)

https://user-images.githubusercontent.com/889383/144760730-f459f771-ec15-452a-b398-8709b0a9a3c2.mp4

