### PR TITLE
Show model object icons in the model explorer tree

### DIFF
--- a/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/SampleEMFConfiguration.java
+++ b/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/SampleEMFConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import eu.balticlsc.model.CAL.CALPackage;
-import eu.balticlsc.model.CAL.util.CALAdapterFactory;
+import eu.balticlsc.model.CAL.provider.CALItemProviderAdapterFactory;
 
 /**
  * Configuration of the EMF support for Sirius Web.
@@ -49,13 +49,12 @@ public class SampleEMFConfiguration {
 
     @Bean
     public ILabelFeatureProvider flowLabelFeatureProvider() {
-        return new LabelFeatureProvider(FlowPackage.eINSTANCE.getNsURI(), new FlowLabelFeatureSwitch(),
-                new FlowEditableSwitch());
+        return new LabelFeatureProvider(FlowPackage.eINSTANCE.getNsURI(), new FlowLabelFeatureSwitch(), new FlowEditableSwitch());
     }
 
     @Bean
     public AdapterFactory calAdapterFactory() {
-        return new CALAdapterFactory();
+        return new CALItemProviderAdapterFactory();
     }
 
     @Bean

--- a/frontend/src/views/edit-project/Workbench/Workbench.tsx
+++ b/frontend/src/views/edit-project/Workbench/Workbench.tsx
@@ -151,7 +151,7 @@ export const Workbench = ({
             />
           </div>
         }
-        initialResizablePanelSize={300}
+        initialResizablePanelSize={350}
       />
 
       {/* NOTE: snackbar copied from sirius-components


### PR DESCRIPTION
Fixes paths used for icons shown in the model explorer tree. Uses the icons introduced in fdb8c471d963e22855fee0b8f0494174f19d6b64.

Closes #23

![image](https://user-images.githubusercontent.com/889383/144761715-8cefcdb9-c0aa-4feb-9d05-dda2f4a379f9.png)
