### PR TITLE
Hide domains other than CAL by default

### DIFF
--- a/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/SampleEMFConfiguration.java
+++ b/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/SampleEMFConfiguration.java
@@ -38,16 +38,19 @@ import eu.balticlsc.model.CAL.provider.CALItemProviderAdapterFactory;
 @Configuration
 public class SampleEMFConfiguration {
     @Bean
+    @ConditionalOnProperty(prefix = "org.eclipse.sirius.web.features", name = "flowModel")
     public AdapterFactory flowAdapterFactory() {
         return new FlowItemProviderAdapterFactory();
     }
 
     @Bean
+    @ConditionalOnProperty(prefix = "org.eclipse.sirius.web.features", name = "flowModel")
     public EPackage flowEPackage() {
         return FlowPackage.eINSTANCE;
     }
 
     @Bean
+    @ConditionalOnProperty(prefix = "org.eclipse.sirius.web.features", name = "flowModel")
     public ILabelFeatureProvider flowLabelFeatureProvider() {
         return new LabelFeatureProvider(FlowPackage.eINSTANCE.getNsURI(), new FlowLabelFeatureSwitch(), new FlowEditableSwitch());
     }

--- a/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StereotypeDescriptionRegistryConfigurer.java
+++ b/backend/sirius-web-sample-application/src/main/java/org/eclipse/sirius/web/sample/configuration/StereotypeDescriptionRegistryConfigurer.java
@@ -324,26 +324,32 @@ public class StereotypeDescriptionRegistryConfigurer implements IStereotypeDescr
 
     private final boolean studiosEnabled;
 
-    public StereotypeDescriptionRegistryConfigurer(MeterRegistry meterRegistry,
-            @Value("${org.eclipse.sirius.web.features.studioDefinition:false}") boolean studiosEnabled,
-            Environment environment) {
+    private final boolean flowModelEnabled;
+
+    public StereotypeDescriptionRegistryConfigurer(MeterRegistry meterRegistry, @Value("${org.eclipse.sirius.web.features.studioDefinition:false}") boolean studiosEnabled,
+            @Value("${org.eclipse.sirius.web.features.flowModel:false}") boolean flowModelEnabled, Environment environment) {
         this.environment = Objects.requireNonNull(environment);
         this.stereotypeBuilder = new StereotypeBuilder(TIMER_NAME, meterRegistry);
         this.studiosEnabled = studiosEnabled;
+        this.flowModelEnabled = flowModelEnabled;
         this.random = new Random();
     }
 
     @Override
     public void addStereotypeDescriptions(IStereotypeDescriptionRegistry registry) {
-        registry.add(new StereotypeDescription(EMPTY_FLOW_ID, EMPTY_FLOW_LABEL, this::getEmptyFlowContent));
+        registry.add(new StereotypeDescription(EMPTY_CAL_ID, EMPTY_CAL_LABEL, this::getEmptyCALContent));
+        if (this.flowModelEnabled) {
+            registry.add(new StereotypeDescription(EMPTY_FLOW_ID, EMPTY_FLOW_LABEL, this::getEmptyFlowContent));
+        }
         if (this.studiosEnabled) {
             registry.add(new StereotypeDescription(EMPTY_DOMAIN_ID, EMPTY_DOMAIN_LABEL, this::getEmptyDomainContent));
             registry.add(new StereotypeDescription(EMPTY_VIEW_ID, EMPTY_VIEW_LABEL, this::getEmptyViewContent));
         }
-        registry.add(new StereotypeDescription(ROBOT_FLOW_ID, ROBOT_FLOW_LABEL, this::getRobotFlowContent));
-        registry.add(new StereotypeDescription(BIG_GUY_FLOW_ID, BIG_GUY_FLOW_LABEL, this::getBigGuyFlowContent));
-        registry.add(new StereotypeDescription(EMPTY_CAL_ID, EMPTY_CAL_LABEL, this::getEmptyCALContent));
-        registry.add(new StereotypeDescription(EMPTY_ID, EMPTY_LABEL, "New", this::getEmptyContent)); //$NON-NLS-1$
+        if (this.flowModelEnabled) {
+            registry.add(new StereotypeDescription(ROBOT_FLOW_ID, ROBOT_FLOW_LABEL, this::getRobotFlowContent));
+            registry.add(new StereotypeDescription(BIG_GUY_FLOW_ID, BIG_GUY_FLOW_LABEL, this::getBigGuyFlowContent));
+            registry.add(new StereotypeDescription(EMPTY_ID, EMPTY_LABEL, "New", this::getEmptyContent)); //$NON-NLS-1$
+        }
     }
 
     private String getEmptyDomainContent() {

--- a/backend/sirius-web-sample-application/src/main/resources/application-dev.properties
+++ b/backend/sirius-web-sample-application/src/main/resources/application-dev.properties
@@ -27,3 +27,6 @@ spring.servlet.multipart.max-request-size=256MB
 spring.servlet.multipart.enabled=true
 
 sirius.components.cors.allowedOriginPatterns=*
+
+org.eclipse.sirius.web.features.flowModel=false
+org.eclipse.sirius.web.features.studioDefinition=false

--- a/backend/sirius-web-sample-application/src/main/resources/application.properties
+++ b/backend/sirius-web-sample-application/src/main/resources/application.properties
@@ -28,3 +28,6 @@ sirius.components.cors.allowedOriginPatterns=*
 eu.balticlsc.api-proxy.scheme=https
 eu.balticlsc.api-proxy.hostname=balticlsc.iem.pw.edu.pl
 eu.balticlsc.api-proxy.port=443
+
+org.eclipse.sirius.web.features.flowModel=false
+org.eclipse.sirius.web.features.studioDefinition=false


### PR DESCRIPTION
Domains (coming from metamodels) other than CAL are hidden by default. They can be shown by configuring the following Spring properties:

* `org.eclipse.sirius.web.features.flowModel=true`
* `org.eclipse.sirius.web.features.studioDefinition=true`

For example:

```sh
./scripts/launch.sh \
    --org.eclipse.sirius.web.features.flowModel=true \
    --org.eclipse.sirius.web.features.studioDefinition=true
```

Closes #67


https://user-images.githubusercontent.com/889383/144762474-aa2af01c-1269-4b55-a9f3-9ccde6f80db9.mp4

