### PR TITLE
fix(upgrade-sirius-web): fetch all remotes before applying patches

### DIFF
--- a/scripts/upgrade-sirius-web.sh
+++ b/scripts/upgrade-sirius-web.sh
@@ -39,8 +39,9 @@ echo "Upgrading $commits_to_upstream_tip_count commit(s) to $upstream_tip_rev ($
 
 echo "Generating patch files"
 git format-patch "..$upstream_tip_hash"
-echo "Generated patch files. Applying them in the main repository"
+echo "Generated patch files. Fetching changes from all remotes and applying patches in the main repository"
 popd >/dev/null
+git fetch --all
 if ! git am -3 $submodule_directory/*.patch; then
 	echo ""
 	echo "Could not cleanly apply patches. You are on your own now"


### PR DESCRIPTION
Some patches cannot be updated without fetching commits from the
upstream remote. This is because they reference commits that cannot be
found.

Fetching changes from all remotes (assuming the upstream sirius-web
repository is added as a remote) fixes that problem.