### PR TITLE
chore(thesis): add -f flag to build script

### DIFF
--- a/paper/build.sh
+++ b/paper/build.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+arg="${1:-""}"
+if [[ "$arg" == "-f" ]] || [[ "$arg" == "--force" ]]; then
+	echo "Cleaning existing build artifacts"
+	git clean EE-dyplom.* -xf
+fi
+
 latexmk -xelatex -interaction=nonstopmode ./EE-dyplom.tex


### PR DESCRIPTION
Add a `--force` (`-f`) flag to the script building the thesis.

Forcing the build cleans the build artifacts first, forcing a full rebuild of the PDF.