### PR TITLE
refactor(thesis): remove dots at the end of captions

### DIFF
--- a/paper/tekst/dostosowanie-sirius-web-do-balticlsc.tex
+++ b/paper/tekst/dostosowanie-sirius-web-do-balticlsc.tex
@@ -59,7 +59,7 @@ repozytorium znajduje się na listingu~\ref{lst:pom-eclipse-repository}.
 \begin{lstlisting}[float,
     floatplacement=hb,
     language=XML,
-    caption={Konfiguracja repozytorium \emph{Eclipse} w \texttt{pom.xml}.},
+    caption={Konfiguracja repozytorium \emph{Eclipse} w \texttt{pom.xml}},
     label={lst:pom-eclipse-repository}]
 <repositories>
   <repository>
@@ -79,7 +79,7 @@ to~zademonstrowane na listingu~\ref{lst:pom-packaging} w linii 9.
     floatplacement=hb,
     language=XML,
     caption={Plik \texttt{pom.xml} dla jednego z projektów metamodelu
-      \gls{EMF}.},
+      \gls{EMF}},
     label={lst:pom-packaging}]
 <?xml version="1.0" encoding="UTF-8" ?>
 <project
@@ -112,7 +112,7 @@ Inne wersje nie są wspierane.
 \begin{lstlisting}[float,
     floatplacement=hb,
     language=XML,
-    caption={Konfiguracja rozszerzeń \emph{Maven Tycho} w \texttt{pom.xml}.},
+    caption={Konfiguracja rozszerzeń \emph{Maven Tycho} w \texttt{pom.xml}},
     label={lst:pom-maven-tycho-plugins}]
 <build>
   <plugins>
@@ -200,7 +200,7 @@ listingu~\ref{lst:registering-odesign-path}.
     floatplacement=hb,
     language=Java,
     caption={Rejestracja klas przygotowanego metamodelu EMF w klasie
-    \texttt{SampleEMFConfiguration}.},
+      \texttt{SampleEMFConfiguration}},
     label={lst:registering-emf-classes}]
     @Bean
     public AdapterFactory calAdapterFactory() {
@@ -217,7 +217,7 @@ listingu~\ref{lst:registering-odesign-path}.
     floatplacement=hb,
     language=Java,
     caption={Wskazanie ścieżki do pliku \texttt{*.odesign} w klasie
-    \texttt{SampleSiriusConfiguration}.},
+      \texttt{SampleSiriusConfiguration}},
     label={lst:registering-odesign-path}]
     @Override
     public List<String> getODesignPaths() {
@@ -236,7 +236,7 @@ na~rysunku~\ref{rys:sirius-web-base-metamodel-model}.
 
   \includegraphics[width=0.95\linewidth]{./images/sirius-web-base-metamodel-model.png}
   \caption{Edycja modelu bazującego na przygotowanym metamodelu EMF w
-  \emph{Sirius Web}.}\label{rys:sirius-web-base-metamodel-model}
+    \emph{Sirius Web}}\label{rys:sirius-web-base-metamodel-model}
 \end{figure}
 % \end{noindent}
 
@@ -258,7 +258,7 @@ rysunku~\ref{rys:sirius-web-new-model-template}.
 \begin{lstlisting}[float,
     floatplacement=!hb,
     language=Java,
-    caption={Dodanie nowego pustego szablonu modelu języka CAL.},
+    caption={Dodanie nowego pustego szablonu modelu języka CAL},
     label={lst:empty-cal-model-template}]
     @Override
     public void addStereotypeDescriptions(IStereotypeDescriptionRegistry registry) {
@@ -282,7 +282,7 @@ rysunku~\ref{rys:sirius-web-new-model-template}.
 
   \includegraphics[width=0.95\linewidth]{./images/sirius-web-new-model-template.png}
   \caption{Szablon nowego pustego modelu języka
-    \gls{CAL} w \emph{Sirius Web}.}\label{rys:sirius-web-new-model-template}
+    \gls{CAL} w \emph{Sirius Web}}\label{rys:sirius-web-new-model-template}
 \end{figure}
 % \end{noindent}
 
@@ -312,7 +312,7 @@ nazwę klasy grupującej wszystkie testy.
     floatplacement=!hb,
     language=XML,
     caption={Wykorzystanie rozszerzenia \emph{Maven Surefire} w
-    \texttt{pom.xml} projektu z testami metamodelu.},
+      \texttt{pom.xml} projektu z testami metamodelu},
     label={lst:pom-maven-surefire-plugin}]
 <build>
   <testSourceDirectory>${project.basedir}/src</testSourceDirectory>
@@ -370,7 +370,7 @@ rysunku~\ref{rys:balticlsc-after-adding-unit-call}.
 
   \includegraphics[width=0.95\linewidth]{./images/balticlsc-development-shelf.png}
   \caption{Biblioteka modułów obliczeniowych platformy
-  \emph{BalticLSC}.}\label{rys:balticlsc-development-shelf}
+    \emph{BalticLSC}}\label{rys:balticlsc-development-shelf}
 \end{figure}
 % \end{noindent}
 
@@ -380,7 +380,7 @@ rysunku~\ref{rys:balticlsc-after-adding-unit-call}.
 
   \includegraphics[width=0.95\linewidth]{./images/balticlsc-diagram-toolbox.png}
   \caption{Przybornik dostępny w edytorze diagramów platformy
-  \emph{BalticLSC}.}\label{rys:balticlsc-diagram-toolbox}
+    \emph{BalticLSC}}\label{rys:balticlsc-diagram-toolbox}
 \end{figure}
 % \end{noindent}
 
@@ -390,7 +390,7 @@ rysunku~\ref{rys:balticlsc-after-adding-unit-call}.
 
   \includegraphics[width=0.95\linewidth]{./images/balticlsc-after-adding-unit-call.png}
   \caption{Edytor diagramów \emph{BalticLSC} po dodaniu modułu obliczeniowego z
-  przybornika.}\label{rys:balticlsc-after-adding-unit-call}
+    przybornika}\label{rys:balticlsc-after-adding-unit-call}
 \end{figure}
 % \end{noindent}
 
@@ -450,7 +450,7 @@ wytworzony przez osobę próbującą podszyć się pod danego użytkownika.
     floatplacement=hb,
     language=java,
     caption={Zawartość pola z danymi w tokenie \gls{JWT} z serwisu
-      \emph{BalticLSC}.},
+      \emph{BalticLSC}},
     label={lst:balticlsc-jwt-payload}]
 {
   "unique_name": "demo",
@@ -492,7 +492,7 @@ rysunku~\ref{rys:balticlsc-change-jwt-modal}.
 
   \includegraphics[width=0.95\linewidth]{./images/balticlsc-change-jwt-modal-with-instructions.png}
   \caption{Okno dialogowe do wprowadzenia tokenu \gls{JWT}
-    użytkownika.}\label{rys:balticlsc-change-jwt-modal}
+    użytkownika}\label{rys:balticlsc-change-jwt-modal}
 \end{figure}
 % \end{noindent}
 
@@ -525,7 +525,7 @@ rysunku~\ref{rys:balticlsc-proxy-sequence-diagram}.
 
   \includegraphics[width=0.95\linewidth]{./images/balticlsc-proxy-sequence-diagram.pdf}
   \caption{Diagram sekwencji pobierania listy modułów obliczeniowych z
-    wykorzystaniem serwera pośredniczącego.}\label{rys:balticlsc-proxy-sequence-diagram}
+    wykorzystaniem serwera pośredniczącego}\label{rys:balticlsc-proxy-sequence-diagram}
 \end{figure}
 % \end{noindent}
 
@@ -668,7 +668,7 @@ zainstalowana w projekcie \emph{Sirius Web}.
 
 	\includegraphics[width=0.95\linewidth]{./images/sirius-web-toolbox.png}
 	\caption{Przybornik dodany w \emph{Sirius
-			Web}.}\label{rys:sirius-web-toolbox}
+			Web}}\label{rys:sirius-web-toolbox}
 \end{figure}
 
 \subsection{Dodanie wywołania modułu obliczeniowego do modelu}
@@ -1021,7 +1021,7 @@ jest na rysunku~\ref{rys:sirius-web-semantic-validation-class-diagram}.
 
   \includegraphics[width=0.95\linewidth]{./images/sirius-web-semantic-validation-class-diagram.pdf}
   \caption{Diagram klas związanych z walidacją semantyczną w \emph{Sirius
-    Web}.}\label{rys:sirius-web-semantic-validation-class-diagram}
+    Web}}\label{rys:sirius-web-semantic-validation-class-diagram}
 \end{figure}
 % \end{noindent}
 
@@ -1278,7 +1278,7 @@ moduł w tym formacie.
 
   \includegraphics[width=0.99\linewidth]{./images/sirius-web-library-class-diagram.pdf}
   \caption{Diagram klas modułu wyświetlającego edytor diagramów \emph{Sirius
-    Web}.}\label{rys:sirius-web-library-class-diagram}
+    Web}}\label{rys:sirius-web-library-class-diagram}
 \end{figure}
 % \end{noindent}
 

--- a/paper/tekst/edytory-graficzne-metamodelowanie.tex
+++ b/paper/tekst/edytory-graficzne-metamodelowanie.tex
@@ -56,11 +56,10 @@ właściciel, jak i samochody są zawarte w obiekcie właściciela.
 
 	\includegraphics[width=0.95\linewidth]{./images/invalid-uml-example.pdf}
 	\caption{Przykład modelu \gls{UML} nieprawidłowego
-		semantycznie.}\label{rys:nieprawidlowy-model-uml}
+		semantycznie}\label{rys:nieprawidlowy-model-uml}
 	\medskip
 	{\small Relacje kompozycji wskazują, że obie klasy są częścią drugiej z
-		klas,
-		co jest nielogiczne.}
+		klas, co jest nielogiczne.}
 \end{figure}
 
 Dopiero znając znaczenie relacji kompozycji można zauważyć ten błąd semantyczny
@@ -74,7 +73,7 @@ poprawny zarówno składniowo, jak i semantycznie.
 
 	\includegraphics[width=0.95\linewidth]{./images/valid-uml-example.pdf}
 	\caption{Przykład prawidłowego modelu
-		\gls{UML}.}\label{rys:prawidlowy-model-uml}
+		\gls{UML}}\label{rys:prawidlowy-model-uml}
 	\medskip
 	{\small Samochód jest częścią klasy \emph{Person}, a więc relacja
 		całość--część jest zrozumiała.}
@@ -124,7 +123,7 @@ metamodelu. W ten sposób można wygenerować na przykład tabelę w~języku
 
 	\includegraphics[width=0.95\linewidth]{./images/visual-studio-dsl-example.png}
 	\caption{Edytowanie modelu w \emph{Visual Studio DSL
-			Tools}.}\label{rys:visual-studio-dsl-example}
+			Tools}}\label{rys:visual-studio-dsl-example}
 \end{figure}
 
 Innym narzędziem umożliwiającym przygotowanie edytora graficznego na podstawie
@@ -143,12 +142,11 @@ podstawie można wygenerować 5 pakietów opisanych w kolejnych akapitach.
 
 	\includegraphics[width=0.95\linewidth]{./images/sirius-desktop-metamodel.png}
 	\caption{Projektowanie metamodelu w \emph{Sirius
-			Desktop}.}\label{rys:sirius-desktop-example-metamodel}
+			Desktop}}\label{rys:sirius-desktop-example-metamodel}
 	\medskip
 	{\small Po lewej dostępne jest drzewo metaklas, na środku diagram
 		metaklas, a po prawej przybornik z~narzędziami do tworzenia
-		elementów
-		metamodelu.}
+		elementów metamodelu.}
 \end{figure}
 
 Pierwszym pakietem jest pakiet bazowy zawierający klasy umożliwiające
@@ -202,7 +200,7 @@ rysunku~\ref{rys:sirius-desktop-example-model}.
 	\includegraphics[width=0.95\linewidth]
 	{./images/sirius-desktop-model-editor.png}
 	\caption{Edycja przykładowego modelu w \emph{Sirius
-			Desktop}.}\label{rys:sirius-desktop-example-model}
+			Desktop}}\label{rys:sirius-desktop-example-model}
 \end{figure}
 
 Piątym pakietem jest pakiet \texttt{.tests}. Można w nim tworzyć testy
@@ -225,7 +223,7 @@ rysunku~\ref{rys:sirius-web-ui}.
 
 	\includegraphics[width=0.95\linewidth]
 	{./images/sirius-web-editor.png}
-	\caption{Edytor modeli \emph{Sirius Web}.}\label{rys:sirius-web-ui}
+	\caption{Edytor modeli \emph{Sirius Web}}\label{rys:sirius-web-ui}
 	{\small Źródło: \url{https://github.com/eclipse-sirius/sirius-web}}
 \end{figure}
 

--- a/paper/tekst/metamodel-dla-jezyka-cal.tex
+++ b/paper/tekst/metamodel-dla-jezyka-cal.tex
@@ -62,7 +62,7 @@ sekwencyjny.
 
 	\includegraphics[width=0.95\linewidth]{./images/balticlsc-example-diagram.png}
 	\caption{Aplikacja obliczeniowa w BalticLSC z obliczeniami
-		sekwencyjnymi.}\label{rys:sekwencyjna-aplikacja-obliczeniowa}
+		sekwencyjnymi}\label{rys:sekwencyjna-aplikacja-obliczeniowa}
 \end{figure}
 
 % \begin{noindent}
@@ -71,7 +71,7 @@ sekwencyjny.
 
 	\includegraphics[width=0.99\linewidth]{./images/balticlsc-concurrent-application-example.png}
 	\caption{Aplikacja obliczeniowa w BalticLSC z możliwością
-		zrównoleglenia obliczeń.}\label{rys:mozliwa-do-zrownoleglenia-aplikacja-obliczeniowa}
+		zrównoleglenia obliczeń}\label{rys:mozliwa-do-zrownoleglenia-aplikacja-obliczeniowa}
 \end{figure}
 % \end{noindent}
 
@@ -90,7 +90,7 @@ istotne z~perspektywy edycji diagramu.
 
 	\includegraphics[width=0.92\linewidth]{./images/cal-emf-metamodel.pdf}
 	\caption{Metamodel EMF języka CAL przygotowany w ramach tej
-		pracy.}\label{rys:cal-emf-metamodel}
+		pracy}\label{rys:cal-emf-metamodel}
 \end{figure}
 
 \begin{figure}[!hb]
@@ -102,7 +102,7 @@ istotne z~perspektywy edycji diagramu.
 
 	\includegraphics[width=0.82\linewidth]{./images/cal-metamodel-balticlsc.png}
 	\caption{Metamodel języka CAL używany w projekcie
-		BalticLSC\@.}\label{rys:cal-metamodel-balticlsc}
+		BalticLSC\@}\label{rys:cal-metamodel-balticlsc}
 
 	\medskip
 	{\small Źródło:
@@ -155,7 +155,7 @@ rysunku~\ref{rys:sirius-desktop-cal-example-model}.
 
 	\includegraphics[width=0.95\linewidth]{./images/sirius-desktop-cal-example-model.png}
 	\caption{Przykładowy diagram reprezentujący model EMF języka CAL w
-		\emph{Sirius Desktop}.}\label{rys:sirius-desktop-cal-example-model}
+		\emph{Sirius Desktop}}\label{rys:sirius-desktop-cal-example-model}
 \end{figure}
 % \end{noindent}
 
@@ -192,7 +192,7 @@ został przedstawiony w listingu~\ref{lst:getDataPinIconPath-method}.
 \begin{lstlisting}[float,
     floatplacement=ht,
     language=Java,
-    caption={Methoda zwracająca nazwę ikony dla portu.},
+    caption={Methoda zwracająca nazwę ikony dla portu},
     label={lst:getDataPinIconPath-method}]
 public String getDataPinIconPath(EObject self) {
   if (!(self instanceof DataPin)) {
@@ -275,7 +275,7 @@ metamodelem i~pomaga uniknąć błędów.
 	\begin{subfigure}{.3\textwidth}
 		\centering
 		\includegraphics[width=.99\linewidth]{./images/sirius-desktop-empty-unit-call.png}
-		\caption{Nowo utworzone wywołanie modułu obliczeniowego.}\label{ref:sirius-desktop-empty-unit-call}
+		\caption{Nowo utworzone wywołanie modułu obliczeniowego}\label{ref:sirius-desktop-empty-unit-call}
     \medskip
     {\small To wywolanie nie~ma~wskazanego modułu, które ma wywołać, stąd
       druga linia etykiety jest pusta.}
@@ -284,7 +284,7 @@ metamodelem i~pomaga uniknąć błędów.
 	\begin{subfigure}{.3\textwidth}
 		\centering
 		\includegraphics[width=.99\linewidth]{./images/sirius-desktop-change-unit-to-call-before.png}
-		\caption{Wywołanie modułu obliczeniowego po wskazaniu modułu do wywołania.}\label{
+		\caption{Wywołanie modułu obliczeniowego po wskazaniu modułu do wywołania}\label{
       rys:sirius-desktop-change-unit-to-call-before}
     \medskip
     {\small Porty zostały automatycznie utworzone zgodnie z~deklaracją modułu
@@ -294,7 +294,7 @@ metamodelem i~pomaga uniknąć błędów.
 	\begin{subfigure}{.3\textwidth}
 		\centering
 		\includegraphics[width=.99\linewidth]{./images/sirius-desktop-change-unit-to-call-after.png}
-		\caption{Wywołanie modułu obliczeniowego po ponownym wskazaniu modułu do wywołania.}\label{
+		\caption{Wywołanie modułu obliczeniowego po ponownym wskazaniu modułu do wywołania}\label{
       rys:sirius-desktop-change-unit-to-call-after}
     \medskip
     {\small Poprzednie porty zostały usunięte, a na ich miejsce zostały
@@ -303,7 +303,7 @@ metamodelem i~pomaga uniknąć błędów.
 	\end{subfigure}
 
 	\caption{Demonstracja działania narzędzia zarządzającego portami wywołań
-    modułów obliczeniowych.}\label{rys:sirius-desktop-change-unit-to-call}
+    modułów obliczeniowych}\label{rys:sirius-desktop-change-unit-to-call}
 \end{figure}
 % \end{noindent}
 
@@ -353,7 +353,7 @@ rysunku~\ref{rys:sirius-desktop-create-unit-call-tool}.
 
 	\includegraphics[width=0.95\linewidth]{./images/sirius-desktop-create-unit-call-tool.png}
 	\caption{Narzędzie do interaktywnego tworzenia nowego wywołania modułu
-		obliczeniowego w~\emph{Sirius Desktop}.}\label{rys:sirius-desktop-create-unit-call-tool}
+		obliczeniowego w~\emph{Sirius Desktop}}\label{rys:sirius-desktop-create-unit-call-tool}
 \end{figure}
 % \end{noindent}
 
@@ -392,7 +392,7 @@ rysunku~\ref{rys:sirius-desktop-syntax-validation}.
 
 	\includegraphics[width=0.95\linewidth]{./images/sirius-desktop-syntax-validation.png}
 	\caption{Walidacja składniowa modeli w \emph{Sirius
-  Desktop}.}\label{rys:sirius-desktop-syntax-validation}
+    Desktop}}\label{rys:sirius-desktop-syntax-validation}
 \end{figure}
 % \end{noindent}
 
@@ -440,7 +440,7 @@ takie połączenia są dozwolone.
 		\centering
 		\includegraphics[width=.99\linewidth]{./images/sirius-desktop-example-semantic-validation-rule-tree.png}
 		\caption{Drzewo obiektów składających się na regułę walidacji
-      semantycznej.}\label{rys:sirius-desktop-example-semantic-validation-rule-tree}
+      semantycznej}\label{rys:sirius-desktop-example-semantic-validation-rule-tree}
 	\end{subfigure}
 
   \medskip
@@ -448,7 +448,7 @@ takie połączenia są dozwolone.
 	\begin{subfigure}{.92\textwidth}
 		\centering
 		\includegraphics[width=.99\linewidth]{./images/sirius-desktop-example-semantic-validation-rule-properties.png}
-		\caption{Właściwości reguły walidacji semantycznej.}\label{rys:sirius-desktop-example-semantic-validation-rule-properties}
+		\caption{Właściwości reguły walidacji semantycznej}\label{rys:sirius-desktop-example-semantic-validation-rule-properties}
 	\end{subfigure}
 
   \medskip
@@ -456,21 +456,21 @@ takie połączenia są dozwolone.
 	\begin{subfigure}{.92\textwidth}
 		\centering
 		\includegraphics[width=.99\linewidth]{./images/sirius-desktop-example-semantic-validation-rule-audit.png}
-		\caption{Warunek spełnienia reguły walidacji semantycznej.}\label{rys:sirius-desktop-example-semantic-validation-rule-audit}
+		\caption{Warunek spełnienia reguły walidacji semantycznej}\label{rys:sirius-desktop-example-semantic-validation-rule-audit}
 	\end{subfigure}
 
   \begin{subfigure}{.92\textwidth}
     \centering
     \includegraphics[width=.99\linewidth]{./images/sirius-desktop-example-semantic-validation-rule-failure.png}
     \caption{Błąd --- reguła nie została
-    spełniona.}\label{rys:sirius-desktop-example-semantic-validation-rule-failure}
+    spełniona}\label{rys:sirius-desktop-example-semantic-validation-rule-failure}
   \end{subfigure}
 
 	\caption{Przykładowa reguła walidacji semantycznej w \emph{Sirius
-  Desktop}.}\label{rys:sirius-desktop-example-semantic-validation-rule}
+    Desktop}}\label{rys:sirius-desktop-example-semantic-validation-rule}
   \medskip
   {\small Reguła zabrania występowania połączeń między portami na tym samym
-  wywołaniu modułu obliczeniowego.}
+    wywołaniu modułu obliczeniowego.}
 \end{figure}
 % \end{noindent}
 
@@ -561,6 +561,6 @@ zawiera w sobie grupę
 
 	\includegraphics[width=0.95\linewidth]{./images/sirius-desktop-metamodel-tests.png}
 	\caption{Wynik uruchomienia testów automatycznych
-  metamodelu.}\label{rys:sirius-desktop-metamodel-tests}
+  metamodelu}\label{rys:sirius-desktop-metamodel-tests}
 \end{figure}
 % \end{noindent}

--- a/paper/tekst/wstep.tex
+++ b/paper/tekst/wstep.tex
@@ -24,7 +24,7 @@ rysunku~\ref{rys:przykladowy-model-uml}.
 \begin{figure}[!hb]
 	\centering
 	\includegraphics[width=0.95\linewidth]{./images/example-uml-model.png}
-	\caption{Przykładowy model \gls{UML}.}\label{rys:przykladowy-model-uml}
+	\caption{Przykładowy model \gls{UML}}\label{rys:przykladowy-model-uml}
 \end{figure}
 
 \gls{UML} jest przykładem uniwersalnego języka do opisu modeli klas programu.
@@ -62,7 +62,7 @@ języku \gls{CAL}, który jest opisany za pomocą metamodelu~\cite{cal-metamodel
 
 	\includegraphics[width=0.95\linewidth]{./images/balticlsc-example-diagram.png}
 	\caption{Przykładowy diagram przedstawiający aplikację obliczeniową w
-		BalticLSC\@.}\label{rys:przykladowy-diagram-balticlsc}
+		BalticLSC}\label{rys:przykladowy-diagram-balticlsc}
 \end{figure}
 
 Istniejący edytor diagramów w BalticLSC dostępny jest jako część aplikacji


### PR DESCRIPTION
Captions are not valid sentences and should not end with dots.

Closes #143