### PR TITLE
refactor(thesis): make bibliography style consistent

### DIFF
--- a/paper/EE-dyplom.bib
+++ b/paper/EE-dyplom.bib
@@ -247,7 +247,7 @@
 
 @misc{fp-ts-github,
   author = {Giulio Canti},
-  title = {Repozytorium biblioteki \texttt{fp-ts}},
+  title = {Repozytorium biblioteki \emph{fp-ts}},
   howpublished = {\url{https://github.com/gcanti/fp-ts} [dostęp 2022-01-11] },
 }
 
@@ -259,7 +259,7 @@
 
 @misc{sirius-components-changelog,
   author = {Eclipse},
-  title = {Lista zmian w nowych wersjach projektu \texttt{sirius-components} w serwisie \emph{GitHub}},
+  title = {Lista zmian w nowych wersjach projektu \emph{sirius-components} w serwisie \emph{GitHub}},
   howpublished = {\url{https://github.com/eclipse-sirius/sirius-components/blob/master/CHANGELOG.adoc} [dostęp 2022-01-15] },
 }
 


### PR DESCRIPTION
Use `\emph` for repository names instead of `\texttt`. Matches the style of other technology names.

I didn't end up moving any bibliography items to footnotes. All bibliography items can be used as sources used to produce this thesis.

Closes #145