### PR TITLE
Thesis abbreviations

### DIFF
--- a/paper/.gitignore
+++ b/paper/.gitignore
@@ -1,19 +1,26 @@
 # latexmk build artifacts
 *.acn
+*.acr
+*.alg
 *.app
+*.arc
 *.aux
 *.bbl
 *.bcf
 *.blg
 *.fdb_latexmk
 *.fls
+*.glg
 *.glo
+*.gls
 *.ist
 *.lof
 *.log
 *.lot
 *.out
+*.slg
 *.slo
+*.sls
 *.synctex.gz
 *.toc
 *.xdv

--- a/paper/EE-dyplom.cls
+++ b/paper/EE-dyplom.cls
@@ -710,9 +710,9 @@
 	\pagestyle{plain}
 	\addcontentsline{toc}{chapter}{\acronymstitle}
 	\printglossary[type=\acronymtype,title={}]
-	%    \printglossary[type=symbols,title={}] % problem z symbolami
+	\printglossary[type=symbols,title={}]
 	% Alternatywna lista symboli - do użycia tylko w Overleaf
-	\input{symbols}
+	% \input{symbols}
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/paper/glossary.tex
+++ b/paper/glossary.tex
@@ -1,38 +1,118 @@
-\newacronym{DSL}{DSL}{Domain Specific Language}
-\newacronym{UML}{UML}{Unified Modeling Language}
-\newacronym{CAL}{CAL}{Computation Application Language}
-\newacronym{EMF}{EMF}{Eclipse Modeling Framework}
-\newacronym{MOF}{MOF}{Meta-Object Facility}
-\newacronym{BPMN}{BPMN}{Business Process Model and Notation}
-\newacronym{ERM}{ERM}{Entity-Relationship Model}
-\newacronym{VSIX}{VSIX}{Visual Studio Integration Extension}
-\newacronym{XML}{XML}{Extensible Markup Language}
-\newacronym{AQL}{AQL}{Acceleo Query Language}
-\newacronym{API}{API}{Application Programming Interface}
-\newacronym{URL}{URL}{Uniform Resource Locator}
-\newacronym{JAR}{JAR}{Java archive}
-\newacronym{POM}{POM}{Project Object Model}
-\newacronym{REST}{REST}{Representational state transfer}
-\newacronym{HTTP}{HTTP}{HyperText Transfer Protocol}
-\newacronym{JWT}{JWT}{JSON Web Token}
-\newacronym{CORS}{CORS}{Cross-Origin Resource Sharing}
-\newacronym{DTO}{DTO}{Data Transfer Object}
-\newacronym{DFS}{DFS}{Depth--First Search} % chktex 8
-\newacronym{DOM}{DOM}{Document Object Model}
-\newacronym{ESM}{ESM}{ECMAScript Module}
+\newacronym[description={\emph{Domain Specific Language}, język specyficzny dla
+			danej dziedziny służący uściśleniu
+			komunikacji}]{DSL}{DSL}{Domain Specific
+	Language}
 
-\newglossaryentry{metamodelowanie}{
-	name=metamodelowanie,
-	description={Tworzenie ustrukturyzowanego modelu opisującego model.}
-}
-\newglossaryentry{HTML}{
-	name=HTML,
-	description={HyperText Markup Language, język znaczników do opisu
-			zawartości stron internetowych.}
-}
-\newglossaryentry{IDE}{
-	name=IDE,
-	description={\emph{Integrated Development Environment}, zintegrowane
+\newacronym[description={\emph{Unified Modeling Language}, język wykorzystywany
+			do modelowania systemów}]{UML}{UML}{Unified Modeling
+	Language}
+
+\newacronym[description={\emph{Computation Application
+				Language}, język do opisu aplikacji
+			obliczeniowych w systemie
+			\BalticLSC{}}]{CAL}{CAL}{Computation Application
+	Language}
+
+\newacronym[description={\emph{Eclipse Modeling Framework}, technologia
+			umożliwiająca tworzenie edytorów na bazie
+			metamodeli}]{EMF}{EMF}{Eclipse
+	Modeling Framework}
+
+\newacronym[description={\emph{Meta-Object Facility}, standard umożliwiający
+			wytwarzanie oprogramowania sterowanego
+			modelami}]{MOF}{MOF}{Meta-Object
+	Facility}
+
+\newacronym[description={\emph{Business Process Model and
+				Notation}, notacja do opisu i modelowania
+			procesów biznesowych}]{BPMN}{BPMN}{Business Process
+	Model
+	and Notation}
+
+\newacronym[description={\emph{
+				Entity--Relationship
+				Model}, sposób zapisu
+			relacji między tabelami w bazie danych}]{ERM}{ERM}{
+	Entity--Relationship Model} % chktex 8
+
+\newacronym[description={\emph{Visual Studio Integration Extension},
+			rozszerzenie do edytora \emph{Visual Studio}
+			pozwalające na tworzenie edytorów
+			na bazie metamodeli}]{VSIX}{VSIX}{Visual Studio
+	Integration Extension}
+
+\newacronym[description={\emph{Extensible Markup Language}, uniwersalny język
+			znaczników przeznaczony do zapisu informacji w
+			ustrukturyzowany
+			sposób}]{XML}{XML}{Extensible Markup Language}
+
+\newacronym[description={\emph{Acceleo Query Language}, język wyrażeń
+			umożliwiający wyrażenie dynamicznej logiki w~modelach
+			\EMF{}}]{AQL}{AQL}{Acceleo Query Language}
+
+\newacronym[description={\emph{Application Programming Interface}, interfejs
+			udostępniany przez aplikację, opisujący jak~inne
+			programy mogą się z nią
+			komunikować}]{API}{API}{Application Programming
+	Interface}
+
+\newacronym[description={\emph{Uniform Resource Locator}, format adresowania
+			zasobów w sieci Internet}]{URL}{URL}{Uniform Resource
+	Locator}
+
+\newacronym[description={\emph{Java archive}, archiwum służące kompresji i
+			przechowywaniu klas języka \Java{}}]{JAR}{JAR}{Java
+	archive}
+
+\newacronym[description={\emph{Project Object Model}, model reprezentujący
+			projekt w narzędziu \Maven{}}]{POM}{POM}{Project Object
+	Model}
+
+\newacronym[description={\emph{Representational state transfer}, styl
+			architektury interfejsów serwerów sieciowych skupiający
+			się na zasobach}]{REST}{REST}{Representational state
+	transfer}
+
+\newacronym[description={\emph{HyperText Transfer Protocol}, protokół sieci WWW
+			służący do przesyłania zawartości stron
+			internetowych}]{HTTP}{HTTP}{HyperText
+	Transfer Protocol}
+
+\newacronym[description={\emph{JSON Web Token}, standard żetonów w formacie
+			\emph{JSON} służący uwierzytelnieniu
+			użytkownika}]{JWT}{JWT}{JSON Web Token}
+
+\newacronym[description={\emph{Cross--Origin % chktex 8
+				Resource Sharing}, mechanizm
+			uniemożliwiający nieautoryzowane przesyłanie zapytań do
+			innych
+			stron}]{CORS}{CORS}{
+	Cross--Origin % chktex 8
+	Resource Sharing}
+
+\newacronym[description={\emph{Data Transfer Object}, obiekt stworzony głównie
+			do przesłania danych między dwoma
+			systemami}]{DTO}{DTO}{Data Transfer Object}
+
+\newacronym[description={\emph{Depth--First % chktex 8
+				Search}, algorytm przeszukiwania
+			drzewa wgłąb}]{DFS}{DFS}{
+	Depth--First Search} % chktex 8
+
+\newacronym[description={\emph{Document Object Model}, interfejs pozwalający na
+			dostęp do strony internetowej jako drzewa
+			elementów}]{DOM}{DOM}{Document
+	Object Model}
+
+\newacronym[description={\emph{ECMAScript Module}, standard modułów języka
+			\JavaScript{}}]{ESM}{ESM}{ECMAScript Module}
+
+\newacronym[description={\emph{HyperText Markup Language}, język znaczników do
+			opisu zawartości stron
+			internetowych}]{HTML}{HTML}{HyperText Markup Language}
+
+\newacronym[description={\emph{Integrated Development Environment},
+			zintegrowane
 			środowisko programistyczne. Program ułatwiający
-			rozwijanie oprogramowania.}
-}
+			rozwijanie oprogramowania}]{IDE}{IDE}{Integrated
+	Development Environment}

--- a/paper/latexmkrc
+++ b/paper/latexmkrc
@@ -1,0 +1,23 @@
+# Run `makeglossaries` as part of `latexmk`
+# Source: https://tex.stackexchange.com/a/44316/261160
+
+add_cus_dep('glo', 'gls', 0, 'run_makeglossaries');
+add_cus_dep('acn', 'acr', 0, 'run_makeglossaries');
+
+sub run_makeglossaries {
+    my ($base_name, $path) = fileparse( $_[0] ); #handle -outdir param by splitting path and file, ...
+    pushd $path; # ... cd-ing into folder first, then running makeglossaries ...
+
+    if ( $silent ) {
+        system "makeglossaries -q '$base_name'"; #unix
+    }
+    else {
+        system "makeglossaries '$base_name'"; #unix
+    };
+
+    popd; # ... and cd-ing back again
+}
+
+push @generated_exts, 'glo', 'gls', 'glg';
+push @generated_exts, 'acn', 'acr', 'alg';
+$clean_ext .= ' %R.ist %R.xdy';

--- a/paper/symbols.tex
+++ b/paper/symbols.tex
@@ -1,4 +1,5 @@
 % Ręcznie tworzona lista symboli - substytut w przypadku kompilowania za pomocą Overleaf
+% NOTE: this file is not used. The glossary is compiled using `makeglossaries`
 \flushleft
 
 $\pi$

--- a/paper/tekst/edytory-graficzne-metamodelowanie.tex
+++ b/paper/tekst/edytory-graficzne-metamodelowanie.tex
@@ -16,7 +16,7 @@ wyższym poziomie abstrakcji) to mówimy, że~ten model modelu to
 
 \section{Metamodelowanie}
 
-\emph{\Gls{metamodelowanie}} w kontekście wytwarzania oprogramowania to
+\emph{Metamodelowanie} w kontekście wytwarzania oprogramowania to
 technika polegająca
 na~przygotowaniu abstrakcyjnego modelu (metamodelu) opisującego strukturę
 modeli, które będą wykorzystywane w programie. Metamodel określa jakie są


### PR DESCRIPTION
Describe thesis abreviations and add them to the thesis.

Use `makeglossaries` to automatically generate the glossary instead of filling it in manually. The nice feature of this approach is that the glossary automatically contains backreferences to pages where the terms were used.

`makeglossaries` is run as part of `latexmk`. It produces artifacts which should not be stored in the repository, and thus, were added to `.gitignore`.

I verified that the PDF is changed as expected using https://www.diffchecker.com/pdf-diff/

Closes #148 