### PR TITLE
refactor(thesis): adjust floated element positions

### DIFF
--- a/paper/tekst/dostosowanie-sirius-web-do-balticlsc.tex
+++ b/paper/tekst/dostosowanie-sirius-web-do-balticlsc.tex
@@ -56,7 +56,7 @@ swoim własnym formacie. Fragment pliku \texttt{pom.xml} konfigurujący to
 repozytorium znajduje się na listingu~\ref{lst:pom-eclipse-repository}.
 
 \begin{lstlisting}[float,
-    floatplacement=hb,
+    floatplacement=ht,
     language=XML,
     caption={Konfiguracja repozytorium \Eclipse{} w \texttt{pom.xml}},
     label={lst:pom-eclipse-repository}]
@@ -230,7 +230,7 @@ przeglądarkowej widoczny jest
 na~rysunku~\ref{rys:sirius-web-base-metamodel-model}.
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.95\linewidth]{./images/sirius-web-base-metamodel-model.png}
@@ -276,7 +276,7 @@ rysunku~\ref{rys:sirius-web-new-model-template}.
 \end{lstlisting}
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.95\linewidth]{./images/sirius-web-new-model-template.png}
@@ -374,7 +374,7 @@ rysunku~\ref{rys:balticlsc-after-adding-unit-call}.
 % \end{noindent}
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.95\linewidth]{./images/balticlsc-diagram-toolbox.png}
@@ -384,7 +384,7 @@ rysunku~\ref{rys:balticlsc-after-adding-unit-call}.
 % \end{noindent}
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.95\linewidth]{./images/balticlsc-after-adding-unit-call.png}
@@ -758,7 +758,7 @@ modelu przedstawiony jest na rysunku~\ref{rys:sirius-web-fetch-model-root-id}.
 % browser -) backend: Stop treeEvent ID 2
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.95\linewidth]{./images/sirius-web-fetch-model-root-id.pdf}
@@ -867,7 +867,7 @@ listingu~\ref{lst:sirius-web-createUnitCall-mutation}.
 %     ReturnUnitCall --> End(Koniec)
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.90\linewidth]{./images/sirius-web-create-unit-call-mutation-handler.pdf}

--- a/paper/tekst/edytory-graficzne-metamodelowanie.tex
+++ b/paper/tekst/edytory-graficzne-metamodelowanie.tex
@@ -139,7 +139,7 @@ zapisany w pliku \emphgls{XML} w formacie \emph{ECore} (rozszerzenie
 widoczny jest na rysunku~\ref{rys:sirius-desktop-example-metamodel}. Na jego
 podstawie można wygenerować 5 pakietów opisanych w kolejnych akapitach.
 
-\begin{figure}[!hb]
+\begin{figure}[!ht]
 	\centering
 
 	\includegraphics[width=0.95\linewidth]{./images/sirius-desktop-metamodel.png}

--- a/paper/tekst/metamodel-dla-jezyka-cal.tex
+++ b/paper/tekst/metamodel-dla-jezyka-cal.tex
@@ -93,7 +93,7 @@ istotne z~perspektywy edycji diagramu.
 		ramach tej pracy}\label{rys:cal-emf-metamodel}
 \end{figure}
 
-\begin{figure}[!hb]
+\begin{figure}[!ht]
 	\centering
 
 	% NOTE: this image is pretty tall, so it must be kept much smaller than the

--- a/paper/tekst/ocena-sirius-web.tex
+++ b/paper/tekst/ocena-sirius-web.tex
@@ -177,7 +177,7 @@ użytkownik nie musi wiedzieć które narzędzia mają sens dla wybranego elemen
 niż w \SiriusDesktop{} pod względem intuicyjności interfejsu.
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.95\linewidth]{./images/sirius-desktop-model-editor.png}
@@ -223,7 +223,7 @@ Takie rozwiązanie jest mylące dla użytkownika i pogarsza wrażenia z
 wykorzystania edytora.
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.95\linewidth]{./images/sirius-desktop-blocked-deleting-pins.png}
@@ -233,7 +233,7 @@ wykorzystania edytora.
 % \end{noindent}
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.95\linewidth]{./images/sirius-web-timeout-when-deleting-pins.png}
@@ -435,7 +435,7 @@ Szczegółowe czasy oczekiwania na wyświetlenie elementów interfejsu z włącz
 sztucznym opóźnieniem zostały zaprezentowane w
 tabeli~\ref{tab:sirius-web-ui-delay-throttled}.
 
-\begin{table}[!b]
+\begin{table}[!t]
 	\centering
 	\begin{tabular}{p{5cm}c}
 		\toprule
@@ -551,7 +551,7 @@ projektu\footnote{
 }.
 
 % \begin{noindent}
-\begin{figure}[!hb]
+\begin{figure}[!ht]
   \centering
 
   \includegraphics[width=0.7\linewidth]{./images/sirius-web-minified-component-names.png}

--- a/paper/tekst/wstep.tex
+++ b/paper/tekst/wstep.tex
@@ -21,7 +21,7 @@ programowania, który może służyć jako początek do późniejszego rozwoju
 aplikacji. Przykładowy model \emphgls{UML} został przedstawiony na
 rysunku~\ref{rys:przykladowy-model-uml}.
 
-\begin{figure}[!hb]
+\begin{figure}[!ht]
 	\centering
 	\includegraphics[width=0.95\linewidth]{./images/example-uml-model.png}
 	\caption{Przykładowy model
@@ -61,7 +61,7 @@ rysunku~\ref{rys:przykladowy-diagram-balticlsc}.  Model obliczeń opisany jest w
 języku \emphgls{CAL}, który jest opisany za pomocą
 metamodelu~\cite{cal-metamodel}.
 
-\begin{figure}[!hb]
+\begin{figure}[!ht]
 	\centering
 
 	\includegraphics[width=0.95\linewidth]{./images/balticlsc-example-diagram.png}


### PR DESCRIPTION
Adjust floated element positions (top <-> bottom) to improve the layout
of floated elements and often get them to appear closer to the place
that references them.

Closes #147