### PR TITLE
Fix thesis document format

### DIFF
--- a/paper/EE-dyplom.cls
+++ b/paper/EE-dyplom.cls
@@ -62,7 +62,7 @@
 \makeglossaries
 \loadglsentries{glossary}
 \ifnum\strcmp{\locallang}{PL} = 0
-	\newcommand{\acronymstitle}{Wykaz skrótów i symboli}
+	\newcommand{\acronymstitle}{Wykaz symboli i skrótów}
 \else
 	\newcommand{\acronymstitle}{List of Abbreviations and Symbols}
 \fi

--- a/paper/EE-dyplom.cls
+++ b/paper/EE-dyplom.cls
@@ -566,33 +566,32 @@
 \renewcommand{\maketitle}{
 	\linespread{1.15}
 
-	% TODO: upewnić się, że czcionki są poprawne (opisane załącznikiem 1. do
-	% zarządzenia 57/2016, czyli:
-	% * Florin SansPl Light
-	% * Helvetica Light (Switzerland Light)
-	% * Helvetica (Switzerland)
-
 	\thispagestyle{empty}
 	\begin{center}
-		\includegraphics[width=\textwidth]{PWHead.png}
-		\vskip 3em
-		\@instytut
-		\vskip 3em
-		\includegraphics[width=\linewidth]{\frontpageheader}
-		\vskip 1em
-		\kieruneklocal \@kierunek
-		\vskip .5em
-		\specjalnosclocal \@specjalnosc
-		\vskip 3em
-		\large \titlelocal
-		\vskip 3em
-		\LARGE \@author \\
-		\normalsize
-		\albumlocal \@album
-		\vskip 2em
-		\promotorlocal\\\@promotor
-		\vfill
-		\citylocal \@date
+		{
+			% Zgodnie z zarządzeniem 57/2016, Arial na stronie tytułowej w
+			% zastępstwie Helvetica
+			\fontfamily{phv}\selectfont
+			\includegraphics[width=\textwidth]{PWHead.png}
+			\vskip 3em
+			\@instytut
+			\vskip 3em
+			\includegraphics[width=\linewidth]{\frontpageheader}
+			\vskip 1em
+			\kieruneklocal \@kierunek
+			\vskip .5em
+			\specjalnosclocal \@specjalnosc
+			\vskip 3em
+			\large \titlelocal
+			\vskip 3em
+			\LARGE \@author \\
+			\normalsize
+			\albumlocal \@album
+			\vskip 2em
+			\promotorlocal\\\@promotor
+			\vfill
+			\citylocal \@date
+		}
 	\end{center}
 }
 

--- a/paper/EE-dyplom.cls
+++ b/paper/EE-dyplom.cls
@@ -582,7 +582,15 @@
 			\vskip .5em
 			\specjalnosclocal \@specjalnosc
 			\vskip 3em
-			\large \titlelocal
+
+			% Sztuczne zmniejszenie dostępnej szerokości strony dla tytułu
+			% Dzięki temu do kolejnej linii przechodzi "Sirius Web", a nie samo "Web"
+			% Źródło https://tex.stackexchange.com/a/330166/261160
+			\begin{minipage}{15cm}
+				\centering
+				\large \titlelocal
+			\end{minipage}
+
 			\vskip 3em
 			\LARGE \@author \\
 			\normalsize


### PR DESCRIPTION
Make the thesis document match the format required by WUT.

* Use a serif font (Arial/Helvetica, supposedly) on the title page

    I am surprised the thesis template uses a sans-serif font (the default one) for the title page, against the rules.

* Rename the list of symbols and abbreviations to match the required title
* Improve line break in the thesis title on the title page (move "Sirius Web" to the new line, not only "Web")

The rest of the requirements are met. Most formatting suggestions are not applied, but they are merely suggestions, and supposedly the thesis template author consciously didn't use them (see comments in `EE-dyplom.cls`).

Closes #81 